### PR TITLE
[FLINK-8331][core] fix FieldParser do not correctly set EMPT_COLUMN e…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/parser/BooleanParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/BooleanParser.java
@@ -37,34 +37,25 @@ public class BooleanParser extends FieldParser<Boolean> {
 	};
 
 	@Override
-	public int parseField(byte[] bytes, int startPos, int limit, byte[] delim, Boolean reuse) {
+	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Boolean reuse) {
 
-		final int delimLimit = limit - delim.length + 1;
+		final int i = nextStringEndPos(bytes, startPos, limit, delimiter);
 
-		int i = startPos;
-
-		while (i < limit) {
-			if (i < delimLimit && delimiterNext(bytes, i, delim)) {
-				if (i == startPos) {
-					setErrorState(ParseErrorState.EMPTY_COLUMN);
-					return -1;
-				}
-				break;
-			}
-			i++;
+		if (i < 0) {
+			return -1;
 		}
 
 		for (byte[] aTRUE : TRUE) {
 			if (byteArrayEquals(bytes, startPos, i - startPos, aTRUE)) {
 				result = true;
-				return (i == limit) ? limit : i + delim.length;
+				return (i == limit) ? limit : i + delimiter.length;
 			}
 		}
 
 		for (byte[] aFALSE : FALSE) {
 			if (byteArrayEquals(bytes, startPos, i - startPos, aFALSE)) {
 				result = false;
-				return (i == limit) ? limit : i + delim.length;
+				return (i == limit) ? limit : i + delimiter.length;
 			}
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/types/parser/ByteParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/ByteParser.java
@@ -28,6 +28,12 @@ public class ByteParser extends FieldParser<Byte> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Byte reusable) {
+
+		if (startPos == limit) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			return -1;
+		}
+
 		int val = 0;
 		boolean neg = false;
 

--- a/flink-core/src/main/java/org/apache/flink/types/parser/ByteValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/ByteValueParser.java
@@ -33,6 +33,12 @@ public class ByteValueParser extends FieldParser<ByteValue> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, ByteValue reusable) {
+
+		if (startPos == limit) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			return -1;
+		}
+
 		int val = 0;
 		boolean neg = false;
 		
@@ -73,7 +79,7 @@ public class ByteValueParser extends FieldParser<ByteValue> {
 				return -1;
 			}
 		}
-		
+
 		reusable.setValue((byte) (neg ? -val : val));
 		return limit;
 	}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
@@ -210,15 +210,15 @@ public abstract class FieldParser<T> {
 
 		while (endPos < limit) {
 			if (endPos < delimLimit && delimiterNext(bytes, endPos, delimiter)) {
-				if (endPos == startPos) {
-					setErrorState(ParseErrorState.EMPTY_COLUMN);
-					return -1;
-				}
 				break;
 			}
 			endPos++;
 		}
 
+		if (endPos == startPos) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			return -1;
+		}
 		return endPos;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/types/parser/IntParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/IntParser.java
@@ -35,8 +35,13 @@ public class IntParser extends FieldParser<Integer> {
 	private int result;
 
 	@Override
-	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Integer 
-		reusable) {
+	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Integer reusable) {
+
+		if (startPos == limit) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			return -1;
+		}
+
 		long val = 0;
 		boolean neg = false;
 

--- a/flink-core/src/main/java/org/apache/flink/types/parser/IntValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/IntValueParser.java
@@ -36,6 +36,12 @@ public class IntValueParser extends FieldParser<IntValue> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, IntValue reusable) {
+
+		if (startPos == limit) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			return -1;
+		}
+
 		long val = 0;
 		boolean neg = false;
 
@@ -75,7 +81,7 @@ public class IntValueParser extends FieldParser<IntValue> {
 				return -1;
 			}
 		}
-		
+
 		reusable.setValue((int) (neg ? -val : val));
 		return limit;
 	}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/LongParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/LongParser.java
@@ -32,6 +32,12 @@ public class LongParser extends FieldParser<Long> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Long reusable) {
+
+		if (startPos == limit) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			return -1;
+		}
+
 		long val = 0;
 		boolean neg = false;
 

--- a/flink-core/src/main/java/org/apache/flink/types/parser/LongValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/LongValueParser.java
@@ -33,6 +33,12 @@ public class LongValueParser extends FieldParser<LongValue> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, LongValue reusable) {
+
+		if (startPos == limit) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			return -1;
+		}
+
 		long val = 0;
 		boolean neg = false;
 

--- a/flink-core/src/main/java/org/apache/flink/types/parser/ShortParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/ShortParser.java
@@ -36,6 +36,12 @@ public class ShortParser extends FieldParser<Short> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Short reusable) {
+
+		if (startPos == limit) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			return -1;
+		}
+
 		int val = 0;
 		boolean neg = false;
 
@@ -148,6 +154,7 @@ public class ShortParser extends FieldParser<Short> {
 				throw new NumberFormatException("Value overflow/underflow");
 			}
 		}
+
 		return (short) (neg ? -val : val);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/ShortValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/ShortValueParser.java
@@ -36,6 +36,12 @@ public class ShortValueParser extends FieldParser<ShortValue> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, ShortValue reusable) {
+
+		if (startPos == limit) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			return -1;
+		}
+
 		int val = 0;
 		boolean neg = false;
 
@@ -75,7 +81,7 @@ public class ShortValueParser extends FieldParser<ShortValue> {
 				return -1;
 			}
 		}
-		
+
 		reusable.setValue((short) (neg ? -val : val));
 		return limit;
 	}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/StringParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/StringParser.java
@@ -42,6 +42,12 @@ public class StringParser extends FieldParser<String> {
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, String reusable) {
 
+		if (startPos == limit) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			this.result = "";
+			return limit;
+		}
+
 		int i = startPos;
 
 		final int delimLimit = limit - delimiter.length + 1;
@@ -83,10 +89,6 @@ public class StringParser extends FieldParser<String> {
 			}
 
 			if (i >= delimLimit) {
-				// no delimiter found. Take the full string
-				if (limit == startPos) {
-					setErrorState(ParseErrorState.EMPTY_COLUMN); // mark empty column
-				}
 				this.result = new String(bytes, startPos, limit - startPos, getCharset());
 				return limit;
 			} else {

--- a/flink-core/src/main/java/org/apache/flink/types/parser/StringValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/StringValueParser.java
@@ -45,6 +45,12 @@ public class StringValueParser extends FieldParser<StringValue> {
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, StringValue reusable) {
 
+		if (startPos == limit) {
+			setErrorState(ParseErrorState.EMPTY_COLUMN);
+			reusable.setValueAscii(bytes, startPos, 0);
+			return limit;
+		}
+
 		this.result = reusable;
 		int i = startPos;
 
@@ -89,10 +95,6 @@ public class StringValueParser extends FieldParser<StringValue> {
 			}
 
 			if (i >= delimLimit) {
-				// no delimiter found. Take the full string
-				if (limit == startPos) {
-					setErrorState(ParseErrorState.EMPTY_COLUMN); // mark empty column
-				}
 				reusable.setValueAscii(bytes, startPos, limit - startPos);
 				return limit;
 			} else {

--- a/flink-core/src/test/java/org/apache/flink/types/parser/FieldParserTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/FieldParserTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.types.parser;
 
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.types.parser.FieldParser.ParseErrorState;
+
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -43,4 +46,104 @@ public class FieldParserTest {
 		assertFalse(FieldParser.endsWithDelimiter(bytes, 3, delim));
 	}
 
+	@Test
+	public void testNextStringEndPos() throws Exception {
+
+		FieldParser parser = new TestFieldParser<String>();
+		// single-char delimiter
+		byte[] singleCharDelim = "|".getBytes(ConfigConstants.DEFAULT_CHARSET);
+
+		byte[] bytes1 = "a|".getBytes(ConfigConstants.DEFAULT_CHARSET);
+		assertEquals(1, parser.nextStringEndPos(bytes1, 0, bytes1.length, singleCharDelim));
+		assertEquals(-1, parser.nextStringEndPos(bytes1, 1, bytes1.length, singleCharDelim));
+		assertEquals(ParseErrorState.EMPTY_COLUMN, parser.getErrorState());
+
+		parser.resetParserState();
+		assertEquals(-1, parser.nextStringEndPos(bytes1, 1, 1, singleCharDelim));
+		assertEquals(ParseErrorState.EMPTY_COLUMN, parser.getErrorState());
+
+		parser.resetParserState();
+		assertEquals(-1, parser.nextStringEndPos(bytes1, 2, bytes1.length, singleCharDelim));
+		assertEquals(ParseErrorState.EMPTY_COLUMN, parser.getErrorState());
+
+		byte[] bytes2 = "a||".getBytes(ConfigConstants.DEFAULT_CHARSET);
+		parser.resetParserState();
+		assertEquals(-1, parser.nextStringEndPos(bytes2, 1, bytes2.length, singleCharDelim));
+		assertEquals(ParseErrorState.EMPTY_COLUMN, parser.getErrorState());
+
+		byte[] bytes3 = "a|c".getBytes(ConfigConstants.DEFAULT_CHARSET);
+		parser.resetParserState();
+		assertEquals(-1, parser.nextStringEndPos(bytes3, 1, bytes3.length, singleCharDelim));
+		assertEquals(ParseErrorState.EMPTY_COLUMN, parser.getErrorState());
+
+		parser.resetParserState();
+		assertEquals(3, parser.nextStringEndPos(bytes3, 2, bytes3.length, singleCharDelim));
+		assertEquals(ParseErrorState.NONE, parser.getErrorState());
+
+		byte[] bytes4 = "a|c|".getBytes(ConfigConstants.DEFAULT_CHARSET);
+		parser.resetParserState();
+		assertEquals(3, parser.nextStringEndPos(bytes4, 2, bytes4.length, singleCharDelim));
+		assertEquals(ParseErrorState.NONE, parser.getErrorState());
+
+		// multi-char delimiter
+		byte[] multiCharDelim = "|#|".getBytes(ConfigConstants.DEFAULT_CHARSET);
+		byte[] mBytes1 = "a|#|".getBytes(ConfigConstants.DEFAULT_CHARSET);
+		parser.resetParserState();
+		assertEquals(1, parser.nextStringEndPos(mBytes1, 0, mBytes1.length, multiCharDelim));
+		assertEquals(-1, parser.nextStringEndPos(mBytes1, 1, mBytes1.length, multiCharDelim));
+		assertEquals(ParseErrorState.EMPTY_COLUMN, parser.getErrorState());
+
+		parser.resetParserState();
+		assertEquals(-1, parser.nextStringEndPos(mBytes1, 1, 1, multiCharDelim));
+		assertEquals(ParseErrorState.EMPTY_COLUMN, parser.getErrorState());
+
+		byte[] mBytes2 = "a|#||#|".getBytes(ConfigConstants.DEFAULT_CHARSET);
+		parser.resetParserState();
+		assertEquals(-1, parser.nextStringEndPos(mBytes2, 1, mBytes2.length, multiCharDelim));
+		assertEquals(ParseErrorState.EMPTY_COLUMN, parser.getErrorState());
+
+		byte[] mBytes3 = "a|#|b".getBytes(ConfigConstants.DEFAULT_CHARSET);
+		parser.resetParserState();
+		assertEquals(-1, parser.nextStringEndPos(mBytes3, 1, mBytes3.length, multiCharDelim));
+		assertEquals(ParseErrorState.EMPTY_COLUMN, parser.getErrorState());
+
+		parser.resetParserState();
+		assertEquals(5, parser.nextStringEndPos(mBytes3, 2, mBytes3.length, multiCharDelim));
+		assertEquals(ParseErrorState.NONE, parser.getErrorState());
+
+		byte[] mBytes4 = "a|#|b|#|".getBytes(ConfigConstants.DEFAULT_CHARSET);
+		parser.resetParserState();
+		assertEquals(5, parser.nextStringEndPos(mBytes4, 2, mBytes4.length, multiCharDelim));
+		assertEquals(ParseErrorState.NONE, parser.getErrorState());
+
+	}
+
+}
+
+/**
+ * A FieldParser just for nextStringEndPos test.
+ *
+ * @param <T> The type that is parsed.
+ */
+class TestFieldParser<T> extends FieldParser<T>{
+
+	@Override
+	protected int parseField(byte[] bytes, int startPos, int limit, byte[] delim, T reuse) {
+		return 0;
+	}
+
+	@Override
+	public T getLastResult() {
+		return null;
+	}
+
+	@Override
+	public T createValue() {
+		return null;
+	}
+
+	@Override
+	protected void resetParserState() {
+		super.resetParserState();
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/types/parser/ParserTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/ParserTestBase.java
@@ -405,28 +405,31 @@ public abstract class ParserTestBase<T> extends TestLogger {
 	}
 
 	@Test
-	public void testEmptyFieldInIsolation() {
+	public void testTrailingEmptyField() {
 		try {
-			String [] emptyStrings = new String[] {"|"};
-
 			FieldParser<T> parser = getParser();
 
-			for (String emptyString : emptyStrings) {
-				byte[] bytes = emptyString.getBytes(ConfigConstants.DEFAULT_CHARSET);
-				int numRead = parser.parseField(bytes, 0, bytes.length, new byte[]{'|'}, parser.createValue());
+			byte[] bytes = "||".getBytes(ConfigConstants.DEFAULT_CHARSET);
+
+			for (int i = 0; i < 2; i++) {
+
+				// test empty field with trailing delimiter when i = 0,
+				// test empty field with out trailing delimiter when i= 1.
+				int numRead = parser.parseField(bytes, i, bytes.length, new byte[]{'|'}, parser.createValue());
 
 				assertEquals(FieldParser.ParseErrorState.EMPTY_COLUMN, parser.getErrorState());
 
-				if(this.allowsEmptyField()) {
+				if (this.allowsEmptyField()) {
 					assertTrue("Parser declared the empty string as invalid.", numRead != -1);
-					assertEquals("Invalid number of bytes read returned.", bytes.length, numRead);
-				}
-				else {
+					assertEquals("Invalid number of bytes read returned.", i + 1, numRead);
+				} else {
 					assertTrue("Parser accepted the empty string.", numRead == -1);
 				}
+
+				parser.resetParserState();
 			}
-		}
-		catch (Exception e) {
+
+		} catch (Exception e) {
 			System.err.println(e.getMessage());
 			e.printStackTrace();
 			fail("Test erroneous: " + e.getMessage());


### PR DESCRIPTION
…rror state bug


*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
