### PR TITLE
Temp2

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkRelBuilder.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkRelBuilder.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.planner.calcite.FlinkRelFactories.{ExpandFactory, 
 import org.apache.flink.table.planner.expressions.{PlannerWindowProperty, WindowProperty}
 import org.apache.flink.table.planner.plan.QueryOperationConverter
 import org.apache.flink.table.planner.plan.logical.LogicalWindow
-import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalTableAggregate, LogicalWindowAggregate}
+import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalTableAggregate, LogicalWindowAggregate, LogicalWindowTableAggregate}
 import org.apache.flink.table.planner.plan.utils.AggregateUtil
 import org.apache.flink.table.runtime.operators.rank.{RankRange, RankType}
 import org.apache.flink.table.sinks.TableSink
@@ -127,6 +127,9 @@ class FlinkRelBuilder(
     }
   }
 
+  /**
+    * Build window aggregate for either aggregate or table aggregate.
+    */
   def windowAggregate(
       window: LogicalWindow,
       groupKey: GroupKey,
@@ -136,8 +139,12 @@ class FlinkRelBuilder(
     val aggregate = super.aggregate(groupKey, aggCalls).build().asInstanceOf[LogicalAggregate]
 
     // build logical window aggregate from it
-    push(LogicalWindowAggregate.create(window, namedProperties, aggregate))
-    this
+    aggregate match {
+      case logicalAggregate: LogicalAggregate
+        if AggregateUtil.isTableAggregate(logicalAggregate.getAggCallList) =>
+        push(LogicalWindowTableAggregate.create(window, namedProperties, aggregate))
+      case _ => push(LogicalWindowAggregate.create(window, namedProperties, aggregate))
+    }
   }
 
   def queryOperation(queryOperation: QueryOperation): RelBuilder = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.scala
@@ -133,6 +133,21 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
         aggregate.getNamedProperties,
         convAggregate)
 
+    case windowTableAggregate: LogicalWindowTableAggregate =>
+      val correspondingAggregate = new LogicalWindowAggregate(
+        windowTableAggregate.getCluster,
+        windowTableAggregate.getTraitSet,
+        windowTableAggregate.getInput,
+        windowTableAggregate.getGroupSet,
+        windowTableAggregate.getAggCallList,
+        windowTableAggregate.getWindow,
+        windowTableAggregate.getNamedProperties)
+      val convAggregate = convertAggregate(correspondingAggregate)
+      LogicalWindowTableAggregate.create(
+        windowTableAggregate.getWindow,
+        windowTableAggregate.getNamedProperties,
+        convAggregate)
+
     case tableAggregate: LogicalTableAggregate =>
       val correspondingAggregate = LogicalAggregate.create(
         tableAggregate.getInput,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/AggsHandlerCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/AggsHandlerCodeGenerator.scala
@@ -30,7 +30,7 @@ import org.apache.flink.table.planner.expressions.{PlannerProctimeAttribute, Pla
 import org.apache.flink.table.planner.functions.aggfunctions.DeclarativeAggregateFunction
 import org.apache.flink.table.planner.plan.utils.AggregateInfoList
 import org.apache.flink.table.runtime.dataview.{StateListView, StateMapView}
-import org.apache.flink.table.runtime.generated.{AggsHandleFunction, GeneratedAggsHandleFunction, GeneratedNamespaceAggsHandleFunction, GeneratedTableAggsHandleFunction, NamespaceAggsHandleFunction, TableAggsHandleFunction}
+import org.apache.flink.table.runtime.generated.{AggsHandleFunction, TableAggsHandleFunction, GeneratedAggsHandleFunction, GeneratedNamespaceAggsHandleFunction, GeneratedNamespaceTableAggsHandleFunction, GeneratedTableAggsHandleFunction, NamespaceAggsHandleFunction, NamespaceTableAggsHandleFunction}
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
 import org.apache.flink.table.types.DataType
@@ -423,27 +423,7 @@ class AggsHandlerCodeGenerator(
     // gen converter
     val aggExternalType = aggInfoList.getActualAggregateInfos(0).externalResultType
     val recordInputName = newName("recordInput")
-    val converterCode = CodeGenUtils.genToInternal(ctx, aggExternalType, recordInputName)
-
-    def genRecordToBaseRow: String = {
-      val resultType = fromDataTypeToLogicalType(aggExternalType)
-      val resultBaseRowType = PlannerTypeUtils.toRowType(resultType)
-
-      val newCtx = CodeGeneratorContext(ctx.tableConfig)
-      val exprGenerator = new ExprCodeGenerator(newCtx, false).bindInput(resultType)
-      val resultExpr = exprGenerator.generateConverterResultExpression(
-        resultBaseRowType, classOf[GenericRow], "convertResult")
-
-      val resultTypeClass = boxedTypeTermForType(resultType)
-      s"""
-         |${newCtx.reuseMemberCode()}
-         |$resultTypeClass ${exprGenerator.input1Term} = ($resultTypeClass) $converterCode;
-         |${newCtx.reuseLocalVariableCode()}
-         |${newCtx.reuseInputUnboxingCode()}
-         |${resultExpr.code}
-         |return ${resultExpr.resultTerm};
-       """.stripMargin
-    }
+    val recordToBaseRowCode = genRecordToBaseRow(aggExternalType, recordInputName)
 
     val functionName = newName(name)
     val functionCode =
@@ -537,7 +517,7 @@ class AggsHandlerCodeGenerator(
             }
 
             public $BASE_ROW convertToBaseRow(Object $recordInputName) throws Exception {
-              $genRecordToBaseRow
+              $recordToBaseRowCode
             }
 
             @Override
@@ -564,7 +544,7 @@ class AggsHandlerCodeGenerator(
   }
 
   /**
-    * Generate [[GeneratedAggsHandleFunction]] with the given function name and aggregate infos
+    * Generate [[NamespaceAggsHandleFunction]] with the given function name and aggregate infos
     * and window properties.
     */
   def generateNamespaceAggsHandler[N](
@@ -656,6 +636,148 @@ class AggsHandlerCodeGenerator(
       """.stripMargin
 
     new GeneratedNamespaceAggsHandleFunction[N](functionName, functionCode, ctx.references.toArray)
+  }
+
+  /**
+    * Generate [[NamespaceTableAggsHandleFunction]] with the given function name and aggregate infos
+    * and window properties.
+    */
+  def generateNamespaceTableAggsHandler[N](
+    name: String,
+    aggInfoList: AggregateInfoList,
+    windowProperties: Seq[PlannerWindowProperty],
+    windowClass: Class[N]): GeneratedNamespaceTableAggsHandleFunction[N] = {
+
+    initialWindowProperties(windowProperties, windowClass)
+    initialAggregateInformation(aggInfoList)
+
+    // generates all methods body first to add necessary reuse code to context
+    val createAccumulatorsCode = genCreateAccumulators()
+    val getAccumulatorsCode = genGetAccumulators()
+    val setAccumulatorsCode = genSetAccumulators()
+    val accumulateCode = genAccumulate()
+    val retractCode = genRetract()
+    val mergeCode = genMerge()
+    val emitValueCode = genEmitValue(isWindow = true)
+
+    // gen converter
+    val aggExternalType = aggInfoList.getActualAggregateInfos(0).externalResultType
+    val recordInputName = newName("recordInput")
+    val recordToBaseRowCode = genRecordToBaseRow(aggExternalType, recordInputName)
+
+    val functionName = newName(name)
+    val functionCode =
+      j"""
+        public final class $functionName
+          implements ${className[NamespaceTableAggsHandleFunction[_]]}<$namespaceClassName> {
+
+          ${ctx.reuseMemberCode()}
+          private $CONVERT_COLLECTOR_TYPE_TERM $MEMBER_COLLECTOR_TERM;
+
+          public $functionName(Object[] references) throws Exception {
+            ${ctx.reuseInitCode()}
+            $MEMBER_COLLECTOR_TERM = new $CONVERT_COLLECTOR_TYPE_TERM(references);
+          }
+
+          @Override
+          public void open($STATE_DATA_VIEW_STORE store) throws Exception {
+            ${ctx.reuseOpenCode()}
+          }
+
+          @Override
+          public void accumulate($BASE_ROW $ACCUMULATE_INPUT_TERM) throws Exception {
+            $accumulateCode
+          }
+
+          @Override
+          public void retract($BASE_ROW $RETRACT_INPUT_TERM) throws Exception {
+            $retractCode
+          }
+
+          @Override
+          public void merge(Object ns, $BASE_ROW $MERGED_ACC_TERM) throws Exception {
+            $namespaceClassName $NAMESPACE_TERM = ($namespaceClassName) ns;
+            $mergeCode
+          }
+
+          @Override
+          public void setAccumulators(Object ns, $BASE_ROW $ACC_TERM)
+          throws Exception {
+            $namespaceClassName $NAMESPACE_TERM = ($namespaceClassName) ns;
+            $setAccumulatorsCode
+          }
+
+          @Override
+          public $BASE_ROW getAccumulators() throws Exception {
+            $getAccumulatorsCode
+          }
+
+          @Override
+          public $BASE_ROW createAccumulators() throws Exception {
+            $createAccumulatorsCode
+          }
+
+          @Override
+          public void emitValue(Object ns, $BASE_ROW $KEY_TERM,
+            $COLLECTOR<$BASE_ROW> $COLLECTOR_TERM) throws Exception {
+
+            $MEMBER_COLLECTOR_TERM.$COLLECTOR_TERM = $COLLECTOR_TERM;
+            $namespaceClassName $NAMESPACE_TERM = ($namespaceClassName) ns;
+            $emitValueCode
+          }
+
+          @Override
+          public void cleanup(Object ns) throws Exception {
+            $namespaceClassName $NAMESPACE_TERM = ($namespaceClassName) ns;
+            ${ctx.reuseCleanupCode()}
+          }
+
+          @Override
+          public void close() throws Exception {
+            ${ctx.reuseCloseCode()}
+          }
+
+          private class $CONVERT_COLLECTOR_TYPE_TERM implements $COLLECTOR {
+            public $COLLECTOR<$BASE_ROW> $COLLECTOR_TERM;
+            private $BASE_ROW timeProperties;
+            private $BASE_ROW key;
+            private $JOINED_ROW outerResult;
+            private $JOINED_ROW innerResult;
+            ${ctx.reuseMemberCode()}
+
+            public $CONVERT_COLLECTOR_TYPE_TERM(java.lang.Object[] references) throws Exception {
+              ${ctx.reuseInitCode()}
+              outerResult = new $JOINED_ROW();
+              innerResult = new $JOINED_ROW();
+            }
+
+            public void reset($BASE_ROW $KEY_TERM, $BASE_ROW timeProperties) {
+              this.timeProperties = timeProperties;
+              this.key = $KEY_TERM;
+            }
+
+            public $BASE_ROW convertToBaseRow(Object $recordInputName) throws Exception {
+              $recordToBaseRowCode
+            }
+
+            @Override
+            public void collect(Object $recordInputName) throws Exception {
+              $BASE_ROW tempBaseRow = convertToBaseRow($recordInputName);
+              innerResult.replace(tempBaseRow, timeProperties);
+              outerResult.replace(key, innerResult);
+              $COLLECTOR_TERM.collect(outerResult);
+            }
+
+            @Override
+            public void close() {
+              $COLLECTOR_TERM.close();
+            }
+          }
+        }
+      """.stripMargin
+
+    new GeneratedNamespaceTableAggsHandleFunction[N](
+      functionName, functionCode, ctx.references.toArray)
   }
 
   private def genCreateAccumulators(): String = {
@@ -812,6 +934,27 @@ class AggsHandlerCodeGenerator(
     }
   }
 
+  private def getWindowExpressions(
+    windowProperties: Seq[PlannerWindowProperty]): Seq[GeneratedExpression] = {
+    windowProperties.map {
+      case w: PlannerWindowStart =>
+        // return a Timestamp(Internal is long)
+        GeneratedExpression(
+          s"$NAMESPACE_TERM.getStart()", "false", "", w.resultType)
+      case w: PlannerWindowEnd =>
+        // return a Timestamp(Internal is long)
+        GeneratedExpression(
+          s"$NAMESPACE_TERM.getEnd()", "false", "", w.resultType)
+      case r: PlannerRowtimeAttribute =>
+        // return a rowtime, use long as internal type
+        GeneratedExpression(
+          s"$NAMESPACE_TERM.getEnd() - 1", "false", "", r.resultType)
+      case p: PlannerProctimeAttribute =>
+        // ignore this property, it will be null at the position later
+        GeneratedExpression("-1L", "true", "", p.resultType)
+    }
+  }
+
   private def genGetValue(): String = {
     val methodName = "getValue"
     ctx.startNewLocalVariableStatement(methodName)
@@ -828,23 +971,7 @@ class AggsHandlerCodeGenerator(
 
     if (hasNamespace) {
       // append window property results
-      val windowExprs = windowProperties.map {
-        case w: PlannerWindowStart =>
-          // return a Timestamp(Internal is long)
-          GeneratedExpression(
-            s"$NAMESPACE_TERM.getStart()", "false", "", w.resultType)
-        case w: PlannerWindowEnd =>
-          // return a Timestamp(Internal is long)
-          GeneratedExpression(
-            s"$NAMESPACE_TERM.getEnd()", "false", "", w.resultType)
-        case r: PlannerRowtimeAttribute =>
-          // return a rowtime, use long as internal type
-          GeneratedExpression(
-            s"$NAMESPACE_TERM.getEnd() - 1", "false", "", r.resultType)
-        case p: PlannerProctimeAttribute =>
-          // ignore this property, it will be null at the position later
-          GeneratedExpression("-1L", "true", "", p.resultType)
-      }
+      val windowExprs = getWindowExpressions(windowProperties)
       valueExprs = valueExprs ++ windowExprs
     }
 
@@ -866,10 +993,65 @@ class AggsHandlerCodeGenerator(
     """.stripMargin
   }
 
-  private def genEmitValue(): String = {
+  private def genEmitValue(isWindow: Boolean = false): String = {
     // validation check
     checkNeededMethods(needEmitValue = true)
-    aggBufferCodeGens(0).asInstanceOf[ImperativeAggCodeGen].emitValue
+    val methodName = "emitValue"
+    ctx.startNewLocalVariableStatement(methodName)
+
+    val windowCode =
+      if (isWindow) {
+        // no need to bind input
+        val exprGenerator = new ExprCodeGenerator(ctx, INPUT_NOT_NULL)
+        var valueExprs = Seq[GeneratedExpression]()
+        if (hasNamespace) {
+        // append window property results
+          val windowExprs = getWindowExpressions(windowProperties)
+          valueExprs = valueExprs ++ windowExprs
+        }
+
+        val aggValueTerm = newName("windowProperties")
+        valueType = RowType.of(valueExprs.map(_.resultType): _*)
+
+        // always create a new result row
+        val resultExpr = exprGenerator.generateResultExpression(
+          valueExprs,
+          valueType,
+          classOf[GenericRow],
+          outRow = aggValueTerm,
+          reusedOutRow = false)
+
+        s"""
+           |${ctx.reuseLocalVariableCode(methodName)}
+           |${resultExpr.code}
+           |$MEMBER_COLLECTOR_TERM.reset($KEY_TERM, ${resultExpr.resultTerm});
+        """.stripMargin
+      } else {
+        ""
+      }
+
+    windowCode + aggBufferCodeGens(0).asInstanceOf[ImperativeAggCodeGen].emitValue
+  }
+
+  private def genRecordToBaseRow(aggExternalType: DataType, recordInputName: String): String = {
+    val resultType = fromDataTypeToLogicalType(aggExternalType)
+    val resultBaseRowType = PlannerTypeUtils.toRowType(resultType)
+
+    val newCtx = CodeGeneratorContext(ctx.tableConfig)
+    val exprGenerator = new ExprCodeGenerator(newCtx, false).bindInput(resultType)
+    val resultExpr = exprGenerator.generateConverterResultExpression(
+      resultBaseRowType, classOf[GenericRow], "convertResult")
+
+    val converterCode = CodeGenUtils.genToInternal(ctx, aggExternalType, recordInputName)
+    val resultTypeClass = boxedTypeTermForType(resultType)
+    s"""
+       |${newCtx.reuseMemberCode()}
+       |$resultTypeClass ${exprGenerator.input1Term} = ($resultTypeClass) $converterCode;
+       |${newCtx.reuseLocalVariableCode()}
+       |${newCtx.reuseInputUnboxingCode()}
+       |${resultExpr.code}
+       |return ${resultExpr.resultTerm};
+       """.stripMargin
   }
 
   private def checkNeededMethods(
@@ -906,6 +1088,7 @@ object AggsHandlerCodeGenerator {
   val COLLECTOR_TERM = "out"
   val MEMBER_COLLECTOR_TERM = "convertCollector"
   val CONVERT_COLLECTOR_TYPE_TERM = "ConvertCollector"
+  val KEY_TERM = "groupKey"
 
   val INPUT_NOT_NULL = false
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnInterval.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnInterval.scala
@@ -482,6 +482,19 @@ class FlinkRelMdColumnInterval private extends MetadataHandler[ColumnInterval] {
       mq: RelMetadataQuery,
       index: Int): ValueInterval = estimateColumnIntervalOfAggregate(agg, mq, index)
 
+  /**
+    * Gets interval of the given column on stream window table aggregate.
+    *
+    * @param agg   stream window table aggregate RelNode
+    * @param mq    RelMetadataQuery instance
+    * @param index the index of the given column
+    * @return interval of the given column on stream window Aggregate
+    */
+  def getColumnInterval(
+    agg: StreamExecGroupWindowTableAggregate,
+    mq: RelMetadataQuery,
+    index: Int): ValueInterval = estimateColumnIntervalOfAggregate(agg, mq, index)
+
   private def estimateColumnIntervalOfAggregate(
       aggregate: SingleRel,
       mq: RelMetadataQuery,
@@ -505,6 +518,7 @@ class FlinkRelMdColumnInterval private extends MetadataHandler[ColumnInterval] {
       case agg: BatchExecWindowAggregateBase => agg.getGrouping ++ agg.getAuxGrouping
       case agg: TableAggregate => agg.getGroupSet.toArray
       case agg: StreamExecGroupTableAggregate => agg.grouping
+      case agg: StreamExecGroupWindowTableAggregate => agg.getGrouping
     }
 
     if (index < groupSet.length) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnInterval.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnInterval.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.metadata
 import org.apache.flink.table.planner.plan.metadata.FlinkMetadata.FilteredColumnInterval
 import org.apache.flink.table.planner.plan.nodes.calcite.TableAggregate
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecGroupAggregateBase
-import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamExecGlobalGroupAggregate, StreamExecGroupAggregate, StreamExecGroupTableAggregate, StreamExecGroupWindowAggregate, StreamExecLocalGroupAggregate}
+import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamExecGlobalGroupAggregate, StreamExecGroupAggregate, StreamExecGroupTableAggregate, StreamExecGroupWindowAggregate, StreamExecGroupWindowTableAggregate, StreamExecLocalGroupAggregate}
 import org.apache.flink.table.planner.plan.stats.ValueInterval
 import org.apache.flink.table.planner.plan.utils.ColumnIntervalUtil
 import org.apache.flink.util.Preconditions.checkArgument
@@ -220,6 +220,14 @@ class FlinkRelMdFilteredColumnInterval private extends MetadataHandler[FilteredC
       mq: RelMetadataQuery,
       columnIndex: Int,
       filterArg: Int): ValueInterval = {
+    estimateFilteredColumnIntervalOfAggregate(aggregate, mq, columnIndex, filterArg)
+  }
+
+  def getFilteredColumnInterval(
+    aggregate: StreamExecGroupWindowTableAggregate,
+    mq: RelMetadataQuery,
+    columnIndex: Int,
+    filterArg: Int): ValueInterval = {
     estimateFilteredColumnIntervalOfAggregate(aggregate, mq, columnIndex, filterArg)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
@@ -22,7 +22,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.functions.utils.ScalarSqlFunction
 import org.apache.flink.table.planner.plan.`trait`.RelModifiedMonotonicity
 import org.apache.flink.table.planner.plan.metadata.FlinkMetadata.ModifiedMonotonicity
-import org.apache.flink.table.planner.plan.nodes.calcite.{Expand, Rank, TableAggregate, WindowAggregate}
+import org.apache.flink.table.planner.plan.nodes.calcite.{Expand, Rank, TableAggregate, WindowAggregate, WindowTableAggregate}
 import org.apache.flink.table.planner.plan.nodes.logical._
 import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchExecCorrelate, BatchExecGroupAggregateBase}
 import org.apache.flink.table.planner.plan.nodes.physical.stream._
@@ -226,6 +226,16 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
   }
 
   def getRelModifiedMonotonicity(
+    rel: WindowTableAggregate,
+    mq: RelMetadataQuery): RelModifiedMonotonicity = {
+    if (allAppend(mq, rel.getInput)) {
+      constants(rel.getRowType.getFieldCount)
+    } else {
+      null
+    }
+  }
+
+  def getRelModifiedMonotonicity(
       rel: TableAggregate, mq: RelMetadataQuery): RelModifiedMonotonicity = {
     getRelModifiedMonotonicityOnTableAggregate(
       rel.getInput, rel.getGroupSet.toArray, rel.getRowType.getFieldCount, mq)
@@ -277,6 +287,16 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
       rel: StreamExecGroupWindowAggregate,
       mq: RelMetadataQuery): RelModifiedMonotonicity = {
     if (allAppend(mq, rel.getInput) && !rel.producesUpdates) {
+      constants(rel.getRowType.getFieldCount)
+    } else {
+      null
+    }
+  }
+
+  def getRelModifiedMonotonicity(
+    rel: StreamExecGroupWindowTableAggregate,
+    mq: RelMetadataQuery): RelModifiedMonotonicity = {
+    if (allAppend(mq, rel.getInput)) {
       constants(rel.getRowType.getFieldCount)
     } else {
       null

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalWindowTableAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalWindowTableAggregate.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.calcite
+
+import java.util
+
+import org.apache.calcite.plan.{Convention, RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.util.ImmutableBitSet
+import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
+import org.apache.flink.table.planner.plan.logical.LogicalWindow
+
+/**
+  * Sub-class of [[WindowTableAggregate]] that is a relational expression which performs window
+  * aggregations but outputs 0 or more records for a group. This class corresponds to Calcite
+  * logical rel.
+  */
+class LogicalWindowTableAggregate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    input: RelNode,
+    groupSet: ImmutableBitSet,
+    groupSets: util.List[ImmutableBitSet],
+    aggCalls: util.List[AggregateCall],
+    window: LogicalWindow,
+    namedProperties: Seq[PlannerNamedWindowProperty])
+  extends WindowTableAggregate(
+    cluster,
+    traitSet,
+    input,
+    groupSet,
+    groupSets,
+    aggCalls,
+    window,
+    namedProperties) {
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): WindowTableAggregate = {
+    new LogicalWindowTableAggregate(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      groupSet,
+      groupSets,
+      aggCalls,
+      window,
+      namedProperties)
+  }
+}
+
+object LogicalWindowTableAggregate {
+
+  def create(
+    window: LogicalWindow,
+    namedProperties: Seq[PlannerNamedWindowProperty],
+    aggregate: Aggregate)
+  : LogicalWindowTableAggregate = {
+
+    val cluster: RelOptCluster = aggregate.getCluster
+    val traitSet: RelTraitSet = cluster.traitSetOf(Convention.NONE)
+    new LogicalWindowTableAggregate(
+      cluster,
+      traitSet,
+      aggregate.getInput,
+      aggregate.getGroupSet,
+      aggregate.getGroupSets,
+      aggregate.getAggCallList,
+      window,
+      namedProperties)
+  }
+
+  def create(logicalWindowAggregate: LogicalWindowAggregate): LogicalWindowTableAggregate = {
+    val cluster: RelOptCluster = logicalWindowAggregate.getCluster
+    val traitSet: RelTraitSet = cluster.traitSetOf(Convention.NONE)
+    new LogicalWindowTableAggregate(
+      cluster,
+      traitSet,
+      logicalWindowAggregate.getInput,
+      logicalWindowAggregate.getGroupSet,
+      logicalWindowAggregate.getGroupSets,
+      logicalWindowAggregate.getAggCallList,
+      logicalWindowAggregate.getWindow,
+      logicalWindowAggregate.getNamedProperties)
+  }
+}
+

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/WindowTableAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/WindowTableAggregate.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.calcite
+
+import java.util
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.{RelNode, RelWriter}
+import org.apache.calcite.util.ImmutableBitSet
+import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.plan.logical.LogicalWindow
+
+/**
+  * Relational operator that represents a window table aggregate. A TableAggregate is similar to the
+  * [[org.apache.calcite.rel.core.Aggregate]] but may output 0 or more records for a group.
+  */
+abstract class WindowTableAggregate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    input: RelNode,
+    groupSet: ImmutableBitSet,
+    groupSets: util.List[ImmutableBitSet],
+    aggCalls: util.List[AggregateCall],
+    window: LogicalWindow,
+    namedProperties: Seq[PlannerNamedWindowProperty])
+  extends TableAggregate(cluster, traitSet, input, groupSet, groupSets, aggCalls) {
+
+  def getWindow: LogicalWindow = window
+
+  def getNamedProperties: Seq[PlannerNamedWindowProperty] = namedProperties
+
+  override def deriveRowType(): RelDataType = {
+    val aggregateRowType = super.deriveRowType()
+    val typeFactory = getCluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+    val builder = typeFactory.builder
+    builder.addAll(aggregateRowType.getFieldList)
+    namedProperties.foreach { namedProp =>
+      builder.add(
+        namedProp.name,
+        typeFactory.createFieldTypeFromLogicalType(namedProp.property.resultType)
+      )
+    }
+    builder.build()
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw)
+      .item("window", window)
+      .item("properties", namedProperties.map(_.name).mkString(", "))
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalWindowTableAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalWindowTableAggregate.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.logical
+
+import java.util
+
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+import org.apache.calcite.util.ImmutableBitSet
+import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
+import org.apache.flink.table.planner.plan.logical.LogicalWindow
+import org.apache.flink.table.planner.plan.nodes.FlinkConventions
+import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalWindowTableAggregate, WindowTableAggregate}
+
+/**
+  * Sub-class of [[WindowTableAggregate]] that is a relational expression which performs window
+  * aggregations but outputs 0 or more records for a group.
+  */
+class FlinkLogicalWindowTableAggregate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    child: RelNode,
+    groupSet: ImmutableBitSet,
+    groupSets: util.List[ImmutableBitSet],
+    aggCalls: util.List[AggregateCall],
+    window: LogicalWindow,
+    namedProperties: Seq[PlannerNamedWindowProperty])
+  extends WindowTableAggregate(
+    cluster,
+    traitSet,
+    child,
+    groupSet,
+    groupSets,
+    aggCalls,
+    window,
+    namedProperties)
+  with FlinkLogicalRel {
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new FlinkLogicalWindowTableAggregate(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      groupSet,
+      groupSets,
+      aggCalls,
+      window,
+      namedProperties)
+  }
+
+  override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
+    val child = this.getInput
+    val rowCnt = mq.getRowCount(child)
+    val rowSize = mq.getAverageRowSize(child)
+    val aggCnt = this.getAggCallList.size
+    // group by CPU cost(multiple by 1.1 to encourage less group keys) + agg call CPU cost
+    val cpuCost: Double = rowCnt * getGroupSet.cardinality() * 1.1 + rowCnt * aggCnt
+    planner.getCostFactory.makeCost(rowCnt, cpuCost, rowCnt * rowSize)
+  }
+}
+
+class FlinkLogicalWindowTableAggregateConverter
+  extends ConverterRule(
+    classOf[LogicalWindowTableAggregate],
+    Convention.NONE,
+    FlinkConventions.LOGICAL,
+    "FlinkLogicalWindowTableAggregateConverter") {
+
+  override def convert(rel: RelNode): RelNode = {
+    val agg = rel.asInstanceOf[LogicalWindowTableAggregate]
+    val newInput = RelOptRule.convert(agg.getInput, FlinkConventions.LOGICAL)
+    val traitSet = newInput.getCluster.traitSet().replace(FlinkConventions.LOGICAL).simplify()
+
+    new FlinkLogicalWindowTableAggregate(
+      rel.getCluster,
+      traitSet,
+      newInput,
+      agg.getGroupSet,
+      agg.getGroupSets,
+      agg.getAggCallList,
+      agg.getWindow,
+      agg.getNamedProperties)
+  }
+}
+
+object FlinkLogicalWindowTableAggregate {
+  val CONVERTER = new FlinkLogicalWindowTableAggregateConverter
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowAggregateBase.scala
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.physical.stream
+
+import java.util
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.calcite.tools.RelBuilder
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.streaming.api.transformations.OneInputTransformation
+import org.apache.flink.table.api.{TableConfig, TableException}
+import org.apache.flink.table.dataformat.BaseRow
+import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator
+import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, EqualiserCodeGenerator}
+import org.apache.flink.table.planner.delegation.StreamPlanner
+import org.apache.flink.table.planner.plan.logical._
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamExecRetractionRules
+import org.apache.flink.table.planner.plan.utils.AggregateUtil.{hasRowIntervalType, hasTimeIntervalType, isProctimeAttribute, isRowtimeAttribute, toDuration, toLong, transformToStreamAggregateInfoList}
+import org.apache.flink.table.planner.plan.utils.{AggregateInfoList, KeySelectorUtil, RelExplainUtil, WindowEmitStrategy}
+import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser
+import org.apache.flink.table.runtime.operators.window.{CountWindow, TimeWindow, WindowOperator, WindowOperatorBuilder}
+import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
+import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo
+import org.apache.flink.table.types.logical.LogicalType
+
+import scala.collection.JavaConversions._
+
+/**
+  * Base streaming group window aggregate physical node for either aggregate or table aggregate.
+  */
+abstract class StreamExecGroupWindowAggregateBase(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    grouping: Array[Int],
+    val aggCalls: Seq[AggregateCall],
+    val window: LogicalWindow,
+    namedProperties: Seq[PlannerNamedWindowProperty],
+    inputTimeFieldIndex: Int,
+    val emitStrategy: Option[WindowEmitStrategy],
+    aggType: String)
+  extends SingleRel(cluster, traitSet, inputRel)
+    with StreamPhysicalRel
+    with StreamExecNode[BaseRow] {
+
+  override def producesUpdates: Boolean = emitStrategy.isDefined && emitStrategy.get.produceUpdates
+
+  override def consumesRetractions = true
+
+  override def needsUpdatesAsRetraction(input: RelNode) = true
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = window match {
+    case TumblingGroupWindow(_, timeField, size)
+      if isRowtimeAttribute(timeField) && hasTimeIntervalType(size) => true
+    case SlidingGroupWindow(_, timeField, size, _)
+      if isRowtimeAttribute(timeField) && hasTimeIntervalType(size) => true
+    case SessionGroupWindow(_, timeField, _)
+      if isRowtimeAttribute(timeField) => true
+    case _ => false
+  }
+
+  def getGrouping: Array[Int] = grouping
+
+  def getWindowProperties: Seq[PlannerNamedWindowProperty] = namedProperties
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw)
+      .itemIf("groupBy", RelExplainUtil.fieldToString(grouping, inputRowType), grouping.nonEmpty)
+      .item("window", window)
+      .itemIf("properties", namedProperties.map(_.name).mkString(", "), namedProperties.nonEmpty)
+      .item("select", RelExplainUtil.streamWindowAggregationToString(
+        inputRowType,
+        grouping,
+        outputRowType,
+        aggCalls,
+        namedProperties))
+      .itemIf("emit",
+        emitStrategy.getOrElse(""), emitStrategy.isDefined && !emitStrategy.get.toString.isEmpty)
+  }
+
+  //~ ExecNode methods -----------------------------------------------------------
+
+  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  }
+
+  override def replaceInputNode(
+    ordinalInParent: Int,
+    newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+    replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
+  }
+
+  override protected def translateToPlanInternal(
+    planner: StreamPlanner): Transformation[BaseRow] = {
+    val config = planner.getTableConfig
+
+    val inputTransform = getInputNodes.get(0).translateToPlan(planner)
+      .asInstanceOf[Transformation[BaseRow]]
+
+    val inputRowTypeInfo = inputTransform.getOutputType.asInstanceOf[BaseRowTypeInfo]
+    val outRowType = BaseRowTypeInfo.of(FlinkTypeFactory.toLogicalRowType(outputRowType))
+
+    val inputIsAccRetract = StreamExecRetractionRules.isAccRetract(input)
+
+    if (inputIsAccRetract) {
+      throw new TableException(
+        s"Group Window $aggType: Retraction on windowed GroupBy $aggType is not supported yet. \n" +
+          "please re-check sql grammar. \n" +
+          s"Note: Windowed GroupBy $aggType should not follow a" +
+          "non-windowed GroupBy aggregation.")
+    }
+
+    val isCountWindow = window match {
+      case TumblingGroupWindow(_, _, size) if hasRowIntervalType(size) => true
+      case SlidingGroupWindow(_, _, size, _) if hasRowIntervalType(size) => true
+      case _ => false
+    }
+
+    if (isCountWindow && grouping.length > 0 && config.getMinIdleStateRetentionTime < 0) {
+      LOG.warn(
+        "No state retention interval configured for a query which accumulates state. " +
+          "Please provide a query configuration with valid retention interval to prevent " +
+          "excessive state size. You may specify a retention time of 0 to not clean up the state.")
+    }
+
+    val aggString = RelExplainUtil.streamWindowAggregationToString(
+      inputRowType,
+      grouping,
+      outputRowType,
+      aggCalls,
+      namedProperties)
+
+    val timeIdx = if (isRowtimeAttribute(window.timeAttribute)) {
+      if (inputTimeFieldIndex < 0) {
+        throw new TableException(
+          s"Group window $aggType must defined on a time attribute, " +
+            "but the time attribute can't be found.\n" +
+            "This should never happen. Please file an issue."
+        )
+      }
+      inputTimeFieldIndex
+    } else {
+      -1
+    }
+
+    val needRetraction = StreamExecRetractionRules.isAccRetract(getInput)
+    val aggInfoList = transformToStreamAggregateInfoList(
+      aggCalls,
+      inputRowType,
+      Array.fill(aggCalls.size)(needRetraction),
+      needInputCount = needRetraction,
+      isStateBackendDataViews = true)
+
+    val aggCodeGenerator = getAggsHandlerCodeGenerator(
+      aggInfoList,
+      config,
+      planner.getRelBuilder,
+      inputRowTypeInfo.getLogicalTypes,
+      needRetraction)
+
+    val aggResultTypes = aggInfoList.getActualValueTypes.map(fromDataTypeToLogicalType)
+    val windowPropertyTypes = namedProperties.map(_.property.resultType).toArray
+    val generator = new EqualiserCodeGenerator(aggResultTypes ++ windowPropertyTypes)
+    val equaliser = generator.generateRecordEqualiser("WindowValueEqualiser")
+
+    val aggValueTypes = aggInfoList.getActualValueTypes.map(fromDataTypeToLogicalType)
+    val accTypes = aggInfoList.getAccTypes.map(fromDataTypeToLogicalType)
+    val operator = createWindowOperator(
+      config,
+      aggCodeGenerator,
+      equaliser,
+      accTypes,
+      windowPropertyTypes,
+      aggValueTypes,
+      inputRowTypeInfo.getLogicalTypes,
+      timeIdx,
+      aggInfoList)
+
+    val operatorName = if (grouping.nonEmpty) {
+      s"window: ($window), " +
+        s"groupBy: (${RelExplainUtil.fieldToString(grouping, inputRowType)}), " +
+        s"select: ($aggString)"
+    } else {
+      s"window: ($window), select: ($aggString)"
+    }
+
+    val transformation = new OneInputTransformation(
+      inputTransform,
+      operatorName,
+      operator,
+      outRowType,
+      inputTransform.getParallelism)
+
+    if (inputsContainSingleton()) {
+      transformation.setParallelism(1)
+      transformation.setMaxParallelism(1)
+    }
+
+    val selector = KeySelectorUtil.getBaseRowSelector(grouping, inputRowTypeInfo)
+
+    // set KeyType and Selector for state
+    transformation.setStateKeySelector(selector)
+    transformation.setStateKeyType(selector.getProducedType)
+    transformation
+  }
+
+  private def getAggsHandlerCodeGenerator(
+    aggInfoList: AggregateInfoList,
+    config: TableConfig,
+    relBuilder: RelBuilder,
+    fieldTypeInfos: Seq[LogicalType],
+    needRetraction: Boolean): AggsHandlerCodeGenerator = {
+
+    val needMerge = window match {
+      case SlidingGroupWindow(_, _, size, _) if hasTimeIntervalType(size) => true
+      case SessionGroupWindow(_, _, _) => true
+      case _ => false
+    }
+
+    val generator = new AggsHandlerCodeGenerator(
+      CodeGeneratorContext(config),
+      relBuilder,
+      fieldTypeInfos,
+      copyInputField = false)
+
+    generator.needAccumulate()
+    if (needMerge) {
+      generator.needMerge(mergedAccOffset = 0, mergedAccOnHeap = false)
+    }
+    if (needRetraction) {
+      generator.needRetract()
+    }
+
+    generator
+  }
+
+  protected def getWindowOperatorBuilder(
+    inputFields: Seq[LogicalType],
+    timeIdx: Int): WindowOperatorBuilder = {
+
+    val builder = WindowOperatorBuilder
+      .builder()
+      .withInputFields(inputFields.toArray)
+
+    val newBuilder = window match {
+      case TumblingGroupWindow(_, timeField, size)
+        if isProctimeAttribute(timeField) && hasTimeIntervalType(size) =>
+        builder.tumble(toDuration(size)).withProcessingTime()
+
+      case TumblingGroupWindow(_, timeField, size)
+        if isRowtimeAttribute(timeField) && hasTimeIntervalType(size) =>
+        builder.tumble(toDuration(size)).withEventTime(timeIdx)
+
+      case TumblingGroupWindow(_, timeField, size)
+        if isProctimeAttribute(timeField) && hasRowIntervalType(size) =>
+        builder.countWindow(toLong(size))
+
+      case TumblingGroupWindow(_, _, _) =>
+        // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
+        // before applying the  windowing logic. Otherwise, this would be the same as a
+        // ProcessingTimeTumblingGroupWindow
+        throw new UnsupportedOperationException(
+          "Event-time grouping windows on row intervals are currently not supported.")
+
+      case SlidingGroupWindow(_, timeField, size, slide)
+        if isProctimeAttribute(timeField) && hasTimeIntervalType(size) =>
+        builder.sliding(toDuration(size), toDuration(slide))
+          .withProcessingTime()
+
+      case SlidingGroupWindow(_, timeField, size, slide)
+        if isRowtimeAttribute(timeField) && hasTimeIntervalType(size) =>
+        builder.sliding(toDuration(size), toDuration(slide))
+          .withEventTime(timeIdx)
+
+      case SlidingGroupWindow(_, timeField, size, slide)
+        if isProctimeAttribute(timeField) && hasRowIntervalType(size) =>
+        builder.countWindow(toLong(size), toLong(slide))
+
+      case SlidingGroupWindow(_, _, _, _) =>
+        // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
+        // before applying the  windowing logic. Otherwise, this would be the same as a
+        // ProcessingTimeTumblingGroupWindow
+        throw new UnsupportedOperationException(
+          "Event-time grouping windows on row intervals are currently not supported.")
+
+      case SessionGroupWindow(_, timeField, gap)
+        if isProctimeAttribute(timeField) =>
+        builder.session(toDuration(gap)).withProcessingTime()
+
+      case SessionGroupWindow(_, timeField, gap)
+        if isRowtimeAttribute(timeField) =>
+        builder.session(toDuration(gap)).withEventTime(timeIdx)
+    }
+
+    if (emitStrategy.isDefined && emitStrategy.get.produceUpdates) {
+      // mark this operator will send retraction and set new trigger
+      newBuilder
+        .withSendRetraction()
+        .triggering(emitStrategy.get.getTrigger)
+    } else {
+      newBuilder
+    }
+  }
+
+  protected def getWindowClass(window: LogicalWindow): Class[_] = {
+    window match {
+      case TumblingGroupWindow(_, _, size) if hasRowIntervalType(size) =>
+        classOf[CountWindow]
+      case SlidingGroupWindow(_, _, size, _) if hasRowIntervalType(size) =>
+        classOf[CountWindow]
+      case _ => classOf[TimeWindow]
+    }
+  }
+
+  protected def createWindowOperator(
+    config: TableConfig,
+    aggCodeGenerator: AggsHandlerCodeGenerator,
+    recordEqualiser: GeneratedRecordEqualiser,
+    accTypes: Array[LogicalType],
+    windowPropertyTypes: Array[LogicalType],
+    aggValueTypes: Array[LogicalType],
+    inputFields: Seq[LogicalType],
+    timeIdx: Int,
+    aggInfoList: AggregateInfoList): WindowOperator[_, _]
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowTableAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowTableAggregate.scala
@@ -18,26 +18,23 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
-import org.apache.flink.table.api.TableConfig
-import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
-import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator
-import org.apache.flink.table.planner.plan.logical._
-import org.apache.flink.table.planner.plan.utils.{AggregateInfoList, WindowEmitStrategy}
-import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser
-import org.apache.flink.table.runtime.operators.window.WindowOperator
-import org.apache.flink.table.types.logical.LogicalType
-
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.rel.RelNode
-
-import java.time.Duration
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
+import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator
+import org.apache.flink.table.planner.plan.logical._
+import org.apache.flink.table.planner.plan.utils.AggregateInfoList
+import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser
+import org.apache.flink.table.runtime.operators.window.WindowOperator
+import org.apache.flink.table.types.logical.LogicalType
 
 /**
-  * Streaming group window aggregate physical node which will be translate to window operator.
+  * Streaming group window table aggregate physical node which will be translate to window operator.
   */
-class StreamExecGroupWindowAggregate(
+class StreamExecGroupWindowTableAggregate(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
@@ -47,8 +44,7 @@ class StreamExecGroupWindowAggregate(
     aggCalls: Seq[AggregateCall],
     window: LogicalWindow,
     namedProperties: Seq[PlannerNamedWindowProperty],
-    inputTimeFieldIndex: Int,
-    emitStrategy: WindowEmitStrategy)
+    inputTimeFieldIndex: Int)
   extends StreamExecGroupWindowAggregateBase(
     cluster,
     traitSet,
@@ -60,11 +56,11 @@ class StreamExecGroupWindowAggregate(
     window,
     namedProperties,
     inputTimeFieldIndex,
-    Some(emitStrategy),
-    "Aggregate") {
+    None,
+    "TableAggregate") {
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
-    new StreamExecGroupWindowAggregate(
+    new StreamExecGroupWindowTableAggregate(
       cluster,
       traitSet,
       inputs.get(0),
@@ -74,8 +70,7 @@ class StreamExecGroupWindowAggregate(
       aggCalls,
       window,
       namedProperties,
-      inputTimeFieldIndex,
-      emitStrategy)
+      inputTimeFieldIndex)
   }
 
   override def createWindowOperator(
@@ -89,16 +84,7 @@ class StreamExecGroupWindowAggregate(
     timeIdx: Int,
     aggInfoList: AggregateInfoList): WindowOperator[_, _] = {
 
-    val aggsHandler = aggCodeGenerator.generateNamespaceAggsHandler(
-      "GroupingWindowAggsHandler",
-      aggInfoList,
-      namedProperties.map(_.property),
-      getWindowClass(window))
-
-    val builder = getWindowOperatorBuilder(inputFields, timeIdx)
-    builder
-      .aggregate(aggsHandler, recordEqualiser, accTypes, aggValueTypes, windowPropertyTypes)
-      .withAllowedLateness(Duration.ofMillis(emitStrategy.getAllowLateness))
-      .build()
+    // TODO: will be implement in the next commit, only for plan test.
+    null
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowTableAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowTableAggregate.scala
@@ -84,7 +84,15 @@ class StreamExecGroupWindowTableAggregate(
     timeIdx: Int,
     aggInfoList: AggregateInfoList): WindowOperator[_, _] = {
 
-    // TODO: will be implement in the next commit, only for plan test.
-    null
+    val aggsHandler = aggCodeGenerator.generateNamespaceTableAggsHandler(
+      "GroupingWindowTableAggsHandler",
+      aggInfoList,
+      namedProperties.map(_.property),
+      getWindowClass(window))
+
+    val builder = getWindowOperatorBuilder(inputFields, timeIdx)
+    builder
+      .aggregate(aggsHandler, accTypes, aggValueTypes, windowPropertyTypes)
+      .build()
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -305,6 +305,7 @@ object FlinkStreamRuleSets {
     FlinkLogicalExpand.CONVERTER,
     FlinkLogicalWatermarkAssigner.CONVERTER,
     FlinkLogicalWindowAggregate.CONVERTER,
+    FlinkLogicalWindowTableAggregate.CONVERTER,
     FlinkLogicalSnapshot.CONVERTER,
     FlinkLogicalMatch.CONVERTER,
     FlinkLogicalSink.CONVERTER
@@ -371,6 +372,7 @@ object FlinkStreamRuleSets {
     StreamExecOverAggregateRule.INSTANCE,
     // window agg
     StreamExecGroupWindowAggregateRule.INSTANCE,
+    StreamExecGroupWindowTableAggregateRule.INSTANCE,
     // join
     StreamExecJoinRule.INSTANCE,
     StreamExecWindowJoinRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecGroupWindowTableAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecGroupWindowTableAggregateRule.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream
+
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
+import org.apache.flink.table.planner.plan.nodes.FlinkConventions
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalWindowTableAggregate
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecGroupWindowTableAggregate
+import org.apache.flink.table.planner.plan.utils.AggregateUtil.{isRowtimeAttribute, timeFieldIndex}
+
+import scala.collection.JavaConversions._
+
+/**
+  * Rule to convert a [[FlinkLogicalWindowTableAggregate]] into a
+  * [[StreamExecGroupWindowTableAggregate]].
+  */
+class StreamExecGroupWindowTableAggregateRule
+  extends ConverterRule(
+    classOf[FlinkLogicalWindowTableAggregate],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.STREAM_PHYSICAL,
+    "StreamExecGroupWindowTableAggregateRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val agg: FlinkLogicalWindowTableAggregate = call.rel(0)
+
+    // check if we have grouping sets
+    val groupSets = agg.getGroupSets.size() != 1 || agg.getGroupSets.get(0) != agg.getGroupSet
+    if (groupSets) {
+      throw new TableException("GROUPING SETS are currently not supported.")
+    }
+
+    true
+  }
+
+  override def convert(rel: RelNode): RelNode = {
+    val agg = rel.asInstanceOf[FlinkLogicalWindowTableAggregate]
+    val input = agg.getInput
+    val inputRowType = input.getRowType
+    val cluster = rel.getCluster
+    val requiredDistribution = if (agg.getGroupSet.cardinality() != 0) {
+      FlinkRelDistribution.hash(agg.getGroupSet.asList)
+    } else {
+      FlinkRelDistribution.SINGLETON
+    }
+    val requiredTraitSet = input.getTraitSet
+      .replace(FlinkConventions.STREAM_PHYSICAL)
+      .replace(requiredDistribution)
+    val providedTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
+    val newInput: RelNode = RelOptRule.convert(input, requiredTraitSet)
+
+    val timeField = agg.getWindow.timeAttribute
+    val inputTimestampIndex = if (isRowtimeAttribute(timeField)) {
+      timeFieldIndex(inputRowType, relBuilderFactory.create(cluster, null), timeField)
+    } else {
+      -1
+    }
+
+    new StreamExecGroupWindowTableAggregate(
+      cluster,
+      providedTraitSet,
+      newInput,
+      rel.getRowType,
+      inputRowType,
+      agg.getGroupSet.toArray,
+      agg.getAggCallList,
+      agg.getWindow,
+      agg.getNamedProperties,
+      inputTimestampIndex)
+  }
+}
+
+object StreamExecGroupWindowTableAggregateRule {
+  val INSTANCE: RelOptRule = new StreamExecGroupWindowTableAggregateRule
+}
+
+

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RelExplainUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RelExplainUtil.scala
@@ -793,7 +793,16 @@ object RelExplainUtil {
       namedProperties: Seq[PlannerNamedWindowProperty],
       withOutputFieldNames: Boolean = true): String = {
     val inFields = inputType.getFieldNames
-    val outFields = rowType.getFieldNames
+    val isTableAggregate = AggregateUtil.isTableAggregate(aggs)
+    val outFields: Seq[String] = if (isTableAggregate) {
+      val outNames = rowType.getFieldNames
+      outNames.slice(0, grouping.length) ++
+        List(s"(${outNames.drop(grouping.length)
+          .dropRight(namedProperties.length).mkString(", ")})") ++
+        outNames.slice(outNames.length - namedProperties.length, outNames.length)
+    } else {
+      rowType.getFieldNames
+    }
     val groupStrings = grouping.map(inFields(_))
 
     val aggStrings = aggs.map(a => {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/GroupWindowTableAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/GroupWindowTableAggregateTest.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testMultiWindow">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2], f1=[$1])
++- LogicalWindowTableAggregate(group=[{}], tableAggregate=[[EmptyTableAggFunc($2)]], window=[SlidingGroupWindow('w2, proctime, 20, 10)], properties=[EXPR$0])
+   +- LogicalProject(proctime=[AS($3, _UTF-16LE'proctime')], c=[$0], f0=[$1], f1=[AS(+($2, 1), _UTF-16LE'f1')])
+      +- LogicalWindowTableAggregate(group=[{2}], tableAggregate=[[EmptyTableAggFunc($0, $1)]], window=[TumblingGroupWindow], properties=[EXPR$0])
+         +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[EXPR$0, f1])
++- GroupWindowTableAggregate(window=[SlidingGroupWindow('w2, proctime, 20, 10)], properties=[EXPR$0], select=[EmptyTableAggFunc(f0) AS (f0, f1), start('w2) AS EXPR$0])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[EXPR$0 AS proctime, c, f0, +(f1, 1) AS f1])
+         +- GroupWindowTableAggregate(groupBy=[c], window=[TumblingGroupWindow], properties=[EXPR$0], select=[c, EmptyTableAggFunc(a, b) AS (f0, f1), proctime('w1) AS EXPR$0])
+            +- Exchange(distribution=[hash[c]])
+               +- TableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTimeMaterializer">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(f0=[$1], _c1=[AS(+($2, 1), _UTF-16LE'_c1')], EXPR$0=[$3], EXPR$1=[$4])
++- LogicalWindowTableAggregate(group=[{4}], tableAggregate=[[EmptyTableAggFunc($0, $1)]], window=[TumblingGroupWindow], properties=[EXPR$0, EXPR$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[f0, +(f1, 1) AS _c1, EXPR$0, EXPR$1])
++- GroupWindowTableAggregate(groupBy=[e], window=[TumblingGroupWindow], properties=[EXPR$0, EXPR$1], select=[e, EmptyTableAggFunc(a, b) AS (f0, f1), start('w) AS EXPR$0, end('w) AS EXPR$1])
+   +- Exchange(distribution=[hash[e]])
+      +- Calc(select=[a, b, c, d, PROCTIME_MATERIALIZE(e) AS e])
+         +- TableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSingleWindow">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(f0=[$1], _c1=[AS(+($2, 1), _UTF-16LE'_c1')], EXPR$0=[$3], EXPR$1=[$4])
++- LogicalWindowTableAggregate(group=[{2}], tableAggregate=[[EmptyTableAggFunc($0, $1)]], window=[TumblingGroupWindow], properties=[EXPR$0, EXPR$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[f0, +(f1, 1) AS _c1, EXPR$0, EXPR$1])
++- GroupWindowTableAggregate(groupBy=[c], window=[TumblingGroupWindow], properties=[EXPR$0, EXPR$1], select=[c, EmptyTableAggFunc(a, b) AS (f0, f1), start('w) AS EXPR$0, end('w) AS EXPR$1])
+   +- Exchange(distribution=[hash[c]])
+      +- TableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnIntervalTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnIntervalTest.scala
@@ -465,6 +465,19 @@ class FlinkRelMdColumnIntervalTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetColumnIntervalOnWindowTableAgg(): Unit = {
+    Array(logicalWindowTableAgg, flinkLogicalWindowTableAgg, streamWindowTableAgg).foreach { agg =>
+      assertEquals(ValueInterval(5, 45), mq.getColumnInterval(agg, 0))
+      assertEquals(null, mq.getColumnInterval(agg, 1))
+      assertEquals(null, mq.getColumnInterval(agg, 2))
+      assertEquals(null, mq.getColumnInterval(agg, 3))
+      assertEquals(null, mq.getColumnInterval(agg, 4))
+      assertEquals(null, mq.getColumnInterval(agg, 5))
+      assertEquals(null, mq.getColumnInterval(agg, 6))
+    }
+  }
+
+  @Test
   def testGetColumnIntervalOnWindowAgg(): Unit = {
     Array(logicalWindowAgg, flinkLogicalWindowAgg, batchGlobalWindowAggWithLocalAgg,
       batchGlobalWindowAggWithoutLocalAgg, streamWindowAgg).foreach { agg =>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnIntervalTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnIntervalTest.scala
@@ -174,6 +174,20 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetColumnIntervalOnWindowTableAggregate(): Unit = {
+    Array(logicalWindowTableAgg, flinkLogicalWindowTableAgg, streamWindowTableAgg).foreach {
+      agg =>
+        assertEquals(ValueInterval(5, 45), mq.getFilteredColumnInterval(agg, 0, -1))
+        assertNull(mq.getFilteredColumnInterval(agg, 1, -1))
+        assertNull(mq.getFilteredColumnInterval(agg, 2, -1))
+        assertNull(mq.getFilteredColumnInterval(agg, 3, -1))
+        assertNull(mq.getFilteredColumnInterval(agg, 4, -1))
+        assertNull(mq.getFilteredColumnInterval(agg, 5, -1))
+        assertNull(mq.getFilteredColumnInterval(agg, 6, -1))
+    }
+  }
+
+  @Test
   def testGetColumnIntervalOnUnion(): Unit = {
     Array(logicalUnion, logicalUnionAll).foreach { union =>
       assertNull(mq.getFilteredColumnInterval(union, 0, -1))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -35,7 +35,7 @@ import org.apache.flink.table.planner.plan.PartialFinalType
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
 import org.apache.flink.table.planner.plan.logical.{LogicalWindow, TumblingGroupWindow}
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
-import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalExpand, LogicalRank, LogicalTableAggregate, LogicalWindowAggregate}
+import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalExpand, LogicalRank, LogicalTableAggregate, LogicalWindowAggregate, LogicalWindowTableAggregate}
 import org.apache.flink.table.planner.plan.nodes.logical._
 import org.apache.flink.table.planner.plan.nodes.physical.batch._
 import org.apache.flink.table.planner.plan.nodes.physical.stream._
@@ -768,6 +768,71 @@ class FlinkRelMdHandlerTestBase {
     )
 
     (logicalTableAgg, flinkLogicalTableAgg, streamExecTableAgg)
+  }
+
+  // equivalent Table API is
+  // tEnv.scan("TemporalTable1")
+  //  .select("c, a, b, rowtime")
+  //  .window(Tumble.over("15.minutes").on("rowtime").as("w"))
+  //  .groupBy("a, w")
+  //  .flatAggregate("top3(c)")
+  //  .select("a, f0, f1, w.start, w.end, w.rowtime, w.proctime")
+  protected lazy val (
+    logicalWindowTableAgg,
+    flinkLogicalWindowTableAgg,
+    streamWindowTableAgg) = {
+
+    relBuilder.scan("TemporalTable1")
+    val ts = relBuilder.peek()
+    val project = relBuilder.project(relBuilder.fields(Seq[Integer](2, 0, 1, 4).toList))
+      .build().asInstanceOf[Project]
+    val program = RexProgram.create(
+      ts.getRowType, project.getProjects, null, project.getRowType, rexBuilder)
+    val aggCallOfWindowAgg = Lists.newArrayList(tableAggCall)
+    val logicalWindowAgg = new LogicalWindowTableAggregate(
+      ts.getCluster,
+      ts.getTraitSet,
+      project,
+      ImmutableBitSet.of(1),
+      ImmutableList.of(ImmutableBitSet.of(1)),
+      aggCallOfWindowAgg,
+      tumblingGroupWindow,
+      namedPropertiesOfWindowAgg)
+
+    val flinkLogicalTs: FlinkLogicalDataStreamTableScan =
+      createDataStreamScan(ImmutableList.of("TemporalTable1"), flinkLogicalTraits)
+    val flinkLogicalWindowAgg = new FlinkLogicalWindowTableAggregate(
+      ts.getCluster,
+      logicalTraits,
+      new FlinkLogicalCalc(ts.getCluster, flinkLogicalTraits, flinkLogicalTs, program),
+      ImmutableBitSet.of(1),
+      ImmutableList.of(ImmutableBitSet.of(1)),
+      aggCallOfWindowAgg,
+      tumblingGroupWindow,
+      namedPropertiesOfWindowAgg)
+
+    val hash01 = FlinkRelDistribution.hash(Array(1), requireStrict = true)
+
+    val streamTs: StreamExecDataStreamScan =
+      createDataStreamScan(ImmutableList.of("TemporalTable1"), streamPhysicalTraits)
+    val streamCalc = new BatchExecCalc(
+      cluster, streamPhysicalTraits, streamTs, program, program.getOutputRowType)
+    val streamExchange = new StreamExecExchange(
+      cluster, streamPhysicalTraits.replace(hash01), streamCalc, hash01)
+    val streamWindowAgg = new StreamExecGroupWindowTableAggregate(
+      cluster,
+      streamPhysicalTraits,
+      streamExchange,
+      flinkLogicalWindowAgg.getRowType,
+      streamExchange.getRowType,
+      Array(1),
+      flinkLogicalWindowAgg.getAggCallList,
+      tumblingGroupWindow,
+      namedPropertiesOfWindowAgg,
+      inputTimeFieldIndex = 2
+    )
+
+    (logicalWindowAgg, flinkLogicalWindowAgg, streamWindowAgg)
   }
 
   // equivalent SQL is

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
@@ -149,6 +149,16 @@ class FlinkRelMdModifiedMonotonicityTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetRelMonotonicityOnWindowTableAggregate(): Unit = {
+    Array(logicalWindowTableAgg, flinkLogicalWindowTableAgg, streamWindowTableAgg).foreach {
+      agg =>
+        assertEquals(
+          new RelModifiedMonotonicity(Array.fill(agg.getRowType.getFieldCount)(CONSTANT)),
+          mq.getRelModifiedMonotonicity(agg))
+    }
+  }
+
+  @Test
   def testGetRelMonotonicityOnAggregate(): Unit = {
     // select b, sum(a) from (select a + 10 as a, b from MyTable3) t group by b
     val aggWithSum = relBuilder.scan("MyTable3")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/GroupWindowTableAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/GroupWindowTableAggregateTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.table
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.{Slide, Tumble}
+import org.apache.flink.table.planner.utils.{EmptyTableAggFunc, TableTestBase}
+import org.junit.Test
+
+class GroupWindowTableAggregateTest extends TableTestBase {
+
+  val util = streamTestUtil()
+  val table = util.addTableSource[(Long, Int, Long, Long)]('a, 'b, 'c, 'd.rowtime, 'e.proctime)
+  val emptyFunc = new EmptyTableAggFunc
+
+  @Test
+  def testSingleWindow(): Unit = {
+    val windowedTable = table
+      .window(Tumble over 5.milli on 'd as 'w)
+      .groupBy('w, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1 + 1, 'w.start, 'w.end)
+
+    util.verifyPlan(windowedTable)
+  }
+
+  @Test
+  def testMultiWindow(): Unit = {
+    val windowedTable = table
+      .window(Tumble over 50.milli on 'e as 'w1)
+      .groupBy('w1, 'c)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('w1.proctime as 'proctime, 'c, 'f0, 'f1 + 1 as 'f1)
+      .window(Slide over 20.milli every 10.milli on 'proctime as 'w2)
+      .groupBy('w2)
+      .flatAggregate(emptyFunc('f0))
+      .select('w2.start, 'f1)
+
+    util.verifyPlan(windowedTable)
+  }
+
+  @Test
+  def testTimeMaterializer(): Unit = {
+    val windowedTable = table
+      .window(Tumble over 5.milli on 'd as 'w)
+      .groupBy('w, 'e)
+      .flatAggregate(emptyFunc('a, 'b))
+      .select('f0, 'f1 + 1, 'w.start, 'w.end)
+
+    util.verifyPlan(windowedTable)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/GroupWindowTableAggregateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/GroupWindowTableAggregateStringExpressionTest.scala
@@ -18,210 +18,214 @@
 
 package org.apache.flink.table.planner.plan.stream.table.stringexpr
 
-import org.apache.flink.table.planner.utils.TableTestBase
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.{Session, Slide, Tumble}
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.planner.utils.{TableTestBase, Top3}
+import org.junit.Test
 
 class GroupWindowTableAggregateStringExpressionTest extends TableTestBase {
-//
-//  @Test
-//  def testRowTimeSlide(): Unit = {
-//    val util = streamTestUtil()
-//    val t = util.addTableSource[(Int, Long, String)]('int, 'long, 'string, 'rowtime)
-//
-//    val top3 = new Top3
-//    util.tableEnv.registerFunction("top3", top3)
-//
-//    // Expression / Scala API
-//    val resScala = t
-//      .window(Slide over 4.hours every 2.hours on 'rowtime as 'w)
-//      .groupBy('w, 'string)
-//      .flatAggregate(top3('int) as ('x, 'y))
-//      .select(
-//        'string,
-//        'x,
-//        'y + 1,
-//        'w.start,
-//        'w.end)
-//
-//    // String / Java API
-//    val resJava = t
-//      .window(Slide.over("4.hours").every("2.hours").on("rowtime").as("w"))
-//      .groupBy("w, string")
-//      .flatAggregate("top3(int) as (x, y)")
-//      .select(
-//        "string, " +
-//        "x, " +
-//        "y + 1, " +
-//        "start(w)," +
-//        "end(w)")
-//
-//    verifyTableEquals(resJava, resScala)
-//  }
-//
-//  @Test
-//  def testRowTimeTumble(): Unit = {
-//    val util = streamTestUtil()
-//    val t = util.addTableSource[(Int, Long, Long, String)]('int, 'long, 'rowtime, 'string)
-//
-//    val top3 = new Top3
-//    util.tableEnv.registerFunction("top3", top3)
-//
-//    // Expression / Scala API
-//    val resScala = t
-//      .window(Tumble over 4.hours on 'rowtime as 'w)
-//      .groupBy('w, 'string)
-//      .flatAggregate(top3('int) as ('x, 'y))
-//      .select(
-//        'string,
-//        'x,
-//        'y + 1,
-//        'w.start,
-//        'w.end)
-//
-//    // String / Java API
-//    val resJava = t
-//      .window(Tumble.over("4.hours").on("rowtime").as("w"))
-//      .groupBy("w, string")
-//      .flatAggregate("top3(int) as (x, y)")
-//      .select(
-//        "string, " +
-//          "x, " +
-//          "y + 1, " +
-//          "start(w)," +
-//          "end(w)")
-//
-//    verifyTableEquals(resJava, resScala)
-//  }
-//
-//  @Test
-//  def testRowTimeSession(): Unit = {
-//    val util = streamTestUtil()
-//    val t = util.addTableSource[(Int, Long, String)]('int, 'long, 'string, 'rowtime)
-//
-//    val top3 = new Top3
-//    util.tableEnv.registerFunction("top3", top3)
-//
-//    // Expression / Scala API
-//    val resScala = t
-//      .window(Session withGap 4.hours on 'rowtime as 'w)
-//      .groupBy('w, 'string)
-//      .flatAggregate(top3('int) as ('x, 'y))
-//      .select(
-//        'string,
-//        'x,
-//        'y + 1,
-//        'w.start,
-//        'w.end)
-//
-//    // String / Java API
-//    val resJava = t
-//      .window(Session.withGap("4.hours").on("rowtime").as("w"))
-//      .groupBy("w, string")
-//      .flatAggregate("top3(int) as (x, y)")
-//      .select(
-//        "string, " +
-//          "x, " +
-//          "y + 1, " +
-//          "start(w)," +
-//          "end(w)")
-//
-//    verifyTableEquals(resJava, resScala)
-//  }
-//  @Test
-//  def testProcTimeSlide(): Unit = {
-//    val util = streamTestUtil()
-//    val t = util.addTableSource[(Int, Long, String)]('int, 'long, 'string, 'proctime)
-//
-//    val top3 = new Top3
-//    util.tableEnv.registerFunction("top3", top3)
-//
-//    // Expression / Scala API
-//    val resScala = t
-//      .window(Slide over 4.hours every 2.hours on 'proctime as 'w)
-//      .groupBy('w)
-//      .flatAggregate(top3('int) as ('x, 'y))
-//      .select(
-//        'x,
-//        'y + 1,
-//        'w.start,
-//        'w.end)
-//
-//    // String / Java API
-//    val resJava = t
-//      .window(Slide.over("4.hours").every("2.hours").on("proctime").as("w"))
-//      .groupBy("w")
-//      .flatAggregate("top3(int) as (x, y)")
-//      .select(
-//          "x, " +
-//          "y + 1, " +
-//          "start(w)," +
-//          "end(w)")
-//
-//    verifyTableEquals(resJava, resScala)
-//  }
-//
-//  @Test
-//  def testProcTimeTumble(): Unit = {
-//    val util = streamTestUtil()
-//    val t = util.addTableSource[(Int, Long, String)]('int, 'long,'string, 'proctime)
-//
-//    val top3 = new Top3
-//    util.tableEnv.registerFunction("top3", top3)
-//
-//    // Expression / Scala API
-//    val resScala = t
-//      .window(Tumble over 4.hours on 'proctime as 'w)
-//      .groupBy('w)
-//      .flatAggregate(top3('int) as ('x, 'y))
-//      .select(
-//        'x,
-//        'y + 1,
-//        'w.start,
-//        'w.end)
-//
-//    // String / Java API
-//    val resJava = t
-//      .window(Tumble.over("4.hours").on("proctime").as("w"))
-//      .groupBy("w")
-//      .flatAggregate("top3(int) as (x, y)")
-//      .select(
-//        "x, " +
-//          "y + 1, " +
-//          "start(w)," +
-//          "end(w)")
-//
-//    verifyTableEquals(resJava, resScala)
-//  }
-//
-//  @Test
-//  def testProcTimeSession(): Unit = {
-//    val util = streamTestUtil()
-//    val t = util.addTableSource[(Int, Long, String)]('int, 'long, 'string, 'proctime)
-//
-//    val top3 = new Top3
-//    util.tableEnv.registerFunction("top3", top3)
-//
-//    // Expression / Scala API
-//    val resScala = t
-//      .window(Session withGap 4.hours on 'proctime as 'w)
-//      .groupBy('w)
-//      .flatAggregate(top3('int) as ('x, 'y))
-//      .select(
-//        'x,
-//        'y + 1,
-//        'w.start,
-//        'w.end)
-//
-//    // String / Java API
-//    val resJava = t
-//      .window(Session.withGap("4.hours").on("proctime").as("w"))
-//      .groupBy("w")
-//      .flatAggregate("top3(int) as (x, y)")
-//      .select(
-//        "x, " +
-//          "y + 1, " +
-//          "start(w)," +
-//          "end(w)")
-//
-//    verifyTableEquals(resJava, resScala)
-//  }
+
+  @Test
+  def testRowTimeSlide(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTableSource[(Int, Long, String)]('int, 'long, 'string, 'rowtime.rowtime)
+
+    val top3 = new Top3
+    util.addFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Slide over 4.hours every 2.hours on 'rowtime as 'w)
+      .groupBy('w, 'string)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'string,
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Slide.over("4.hours").every("2.hours").on("rowtime").as("w"))
+      .groupBy("w, string")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+        "string, " +
+        "x, " +
+        "y + 1, " +
+        "start(w)," +
+        "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+
+  @Test
+  def testRowTimeTumble(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTableSource[(Int, Long, Long, String)]('int, 'long, 'rowtime.rowtime, 'string)
+
+    val top3 = new Top3
+    util.addFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Tumble over 4.hours on 'rowtime as 'w)
+      .groupBy('w, 'string)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'string,
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Tumble.over("4.hours").on("rowtime").as("w"))
+      .groupBy("w, string")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+        "string, " +
+          "x, " +
+          "y + 1, " +
+          "start(w)," +
+          "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+
+  @Test
+  def testRowTimeSession(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTableSource[(Int, Long, String)]('int, 'long, 'string, 'rowtime.rowtime)
+
+    val top3 = new Top3
+    util.addFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Session withGap 4.hours on 'rowtime as 'w)
+      .groupBy('w, 'string)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'string,
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Session.withGap("4.hours").on("rowtime").as("w"))
+      .groupBy("w, string")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+        "string, " +
+          "x, " +
+          "y + 1, " +
+          "start(w)," +
+          "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+  @Test
+  def testProcTimeSlide(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTableSource[(Int, Long, String)]('int, 'long, 'string, 'proctime.proctime)
+
+    val top3 = new Top3
+    util.addFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Slide over 4.hours every 2.hours on 'proctime as 'w)
+      .groupBy('w)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Slide.over("4.hours").every("2.hours").on("proctime").as("w"))
+      .groupBy("w")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+          "x, " +
+          "y + 1, " +
+          "start(w)," +
+          "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+
+  @Test
+  def testProcTimeTumble(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTableSource[(Int, Long, String)]('int, 'long,'string, 'proctime.proctime)
+
+    val top3 = new Top3
+    util.addFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Tumble over 4.hours on 'proctime as 'w)
+      .groupBy('w)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Tumble.over("4.hours").on("proctime").as("w"))
+      .groupBy("w")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+        "x, " +
+          "y + 1, " +
+          "start(w)," +
+          "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
+
+  @Test
+  def testProcTimeSession(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTableSource[(Int, Long, String)]('int, 'long, 'string, 'proctime.proctime)
+
+    val top3 = new Top3
+    util.addFunction("top3", top3)
+
+    // Expression / Scala API
+    val resScala = t
+      .window(Session withGap 4.hours on 'proctime as 'w)
+      .groupBy('w)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select(
+        'x,
+        'y + 1,
+        'w.start,
+        'w.end)
+
+    // String / Java API
+    val resJava = t
+      .window(Session.withGap("4.hours").on("proctime").as("w"))
+      .groupBy("w")
+      .flatAggregate("top3(int) as (x, y)")
+      .select(
+        "x, " +
+          "y + 1, " +
+          "start(w)," +
+          "end(w)")
+
+    verifyTableEquals(resJava, resScala)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/GroupWindowTableAggregateValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/GroupWindowTableAggregateValidationTest.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.table.validation
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.{Slide, Tumble, ValidationException}
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.WeightedAvgWithMerge
+import org.apache.flink.table.planner.utils.{TableTestBase, Top3}
+import org.junit.Test
+
+class GroupWindowTableAggregateValidationTest extends TableTestBase {
+
+  val top3 = new Top3
+  val weightedAvg = new WeightedAvgWithMerge
+  val util = streamTestUtil()
+  val table = util.addTableSource[(Long, Int, String)](
+    'long, 'int, 'string, 'rowtime.rowtime, 'proctime.proctime)
+
+  @Test
+  def testTumbleUdAggWithInvalidArgs(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Given parameters do not match any signature. \n" +
+      "Actual: (java.lang.Long) \nExpected: (int)")
+
+    table
+      .window(Slide over 2.hours every 30.minutes on 'rowtime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('long)) // invalid args
+      .select('string, 'f0)
+  }
+
+  @Test
+  def testInvalidStarInSelection(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Can not use * for window aggregate!")
+
+    val util = streamTestUtil()
+    val table = util.addTableSource[(Long, Int, String)]('long, 'int, 'string, 'proctime.proctime)
+
+    table
+      .window(Tumble over 2.rows on 'proctime as 'w)
+      .groupBy('string, 'w)
+      .flatAggregate(top3('int))
+      .select('*)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowTableAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowTableAggregateITCase.scala
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.table
+
+import java.math.BigDecimal
+
+import org.apache.flink.api.common.time.Time
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.{Session, Slide, Tumble}
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.runtime.utils.TimeTestUtil.TimestampAndWatermarkWithOffset
+import org.apache.flink.table.planner.runtime.utils.{StreamingWithStateTestBase, TestingAppendSink}
+import org.apache.flink.table.planner.utils.Top3
+import org.apache.flink.types.Row
+import org.apache.flink.table.planner.runtime.utils.TestData._
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(classOf[Parameterized])
+class GroupWindowTableAggregateITCase(mode: StateBackendMode)
+  extends StreamingWithStateTestBase(mode) {
+
+  val data = List(
+    (1L, 1, "Hi"),
+    (2L, 2, "Hello"),
+    (4L, 2, "Hello"),
+    (8L, 3, "Hello world"),
+    (16L, 3, "Hello world"))
+
+  val data2 = List(
+    (1L, 1, 1d, 1f, new BigDecimal("1"), "Hi"),
+    (2L, 2, 2d, 2f, new BigDecimal("2"), "Hallo"),
+    (3L, 2, 2d, 2f, new BigDecimal("2"), "Hello"),
+    (4L, 5, 5d, 5f, new BigDecimal("5"), "Hello"),
+    (7L, 3, 3d, 3f, new BigDecimal("3"), "Hello"),
+    (8L, 3, 3d, 3f, new BigDecimal("3"), "Hello world"),
+    (16L, 4, 4d, 4f, new BigDecimal("4"), "Hello world"),
+    (32L, 4, 4d, 4f, new BigDecimal("4"), null.asInstanceOf[String]))
+
+  @Test
+  def testProcessingTimeSlidingGroupWindowOverCount(): Unit = {
+    tEnv.getConfig.setIdleStateRetentionTime(Time.hours(1), Time.hours(2))
+    val stream = failingDataSource(tupleData3)
+    val table = stream.toTable(tEnv, 'int, 'long, 'string, 'proctime.proctime)
+
+    val top3 = new Top3
+
+    val windowedTable = table
+      .window(Slide over 4.rows every 2.rows on 'proctime as 'w)
+      .groupBy('w, 'long)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select('long, 'x, 'y)
+
+    val sink = new TestingAppendSink
+    windowedTable.toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq("4,8,8", "4,9,9", "4,10,10", "5,12,12", "5,13,13", "5,14,14",
+      "6,17,17", "6,18,18", "6,19,19", "6,19,19", "6,20,20", "6,21,21")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testEventTimeSessionGroupWindowOverTime(): Unit = {
+    //To verify the "merge" functionality, we create this test with the following characteristics:
+    // 1. set the Parallelism to 1, and have the test data out of order
+    // 2. create a waterMark with 10ms offset to delay the window emission by 10ms
+    val sessionWindowTestData = List(
+      (1L, 1, "Hello"),
+      (2L, 2, "Hello"),
+      (8L, 8, "Hello"),
+      (9L, 9, "Hello World"),
+      (4L, 4, "Hello"),
+      (16L, 16, "Hello"))
+
+    val top3 = new Top3
+
+    val stream = failingDataSource(sessionWindowTestData)
+      .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset[(Long, Int, String)](10L))
+    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'rowtime.rowtime)
+
+    val windowedTable = table
+      .window(Session withGap 5.milli on 'rowtime as 'w)
+      .groupBy('w, 'string)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1)
+
+    val sink = new TestingAppendSink
+    windowedTable.toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq("Hello,2,2", "Hello,4,4", "Hello,8,8", "Hello World,9,9", "Hello,16,16")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testAllProcessingTimeTumblingGroupWindowOverCount(): Unit = {
+    tEnv.getConfig.setIdleStateRetentionTime(Time.hours(1), Time.hours(2))
+    val stream = failingDataSource(tupleData3)
+    val table = stream.toTable(tEnv, 'int, 'long, 'string, 'proctime.proctime)
+    val top3 = new Top3
+
+    val windowedTable = table
+      .window(Tumble over 7.rows on 'proctime as 'w)
+      .groupBy('w)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+
+    val sink = new TestingAppendSink
+    windowedTable.toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq("5,5", "6,6", "7,7", "12,12", "13,13", "14,14", "19,19", "20,20", "21,21")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testEventTimeTumblingWindow(): Unit = {
+    val stream = failingDataSource(tupleData3)
+      .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset[(Int, Long, String)](0L))
+    val table = stream.toTable(tEnv, 'int, 'long, 'string, 'rowtime.rowtime)
+    val top3 = new Top3
+
+    val windowedTable = table
+      .window(Tumble over 10.milli on 'rowtime as 'w)
+      .groupBy('w, 'long)
+      .flatAggregate(top3('int) as ('x, 'y))
+      .select('w.start, 'w.end, 'long, 'x, 'y + 1)
+
+    val sink = new TestingAppendSink
+    windowedTable.toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "1970-01-01T00:00,1970-01-01T00:00:00.010,1,1,2",
+      "1970-01-01T00:00,1970-01-01T00:00:00.010,2,2,3",
+      "1970-01-01T00:00,1970-01-01T00:00:00.010,2,3,4",
+      "1970-01-01T00:00,1970-01-01T00:00:00.010,3,4,5",
+      "1970-01-01T00:00,1970-01-01T00:00:00.010,3,5,6",
+      "1970-01-01T00:00,1970-01-01T00:00:00.010,3,6,7",
+      "1970-01-01T00:00,1970-01-01T00:00:00.010,4,7,8",
+      "1970-01-01T00:00,1970-01-01T00:00:00.010,4,8,9",
+      "1970-01-01T00:00,1970-01-01T00:00:00.010,4,9,10",
+      "1970-01-01T00:00:00.010,1970-01-01T00:00:00.020,4,10,11",
+      "1970-01-01T00:00:00.010,1970-01-01T00:00:00.020,5,13,14",
+      "1970-01-01T00:00:00.010,1970-01-01T00:00:00.020,5,14,15",
+      "1970-01-01T00:00:00.010,1970-01-01T00:00:00.020,5,15,16",
+      "1970-01-01T00:00:00.010,1970-01-01T00:00:00.020,6,17,18",
+      "1970-01-01T00:00:00.010,1970-01-01T00:00:00.020,6,18,19",
+      "1970-01-01T00:00:00.010,1970-01-01T00:00:00.020,6,19,20",
+      "1970-01-01T00:00:00.020,1970-01-01T00:00:00.030,6,21,22",
+      "1970-01-01T00:00:00.020,1970-01-01T00:00:00.030,6,20,21")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testGroupWindowWithoutKeyInProjection(): Unit = {
+    val data = List(
+      (1L, 1, "Hi", 1, 1),
+      (2L, 2, "Hello", 2, 2),
+      (4L, 2, "Hello", 2, 2),
+      (8L, 3, "Hello world", 3, 3),
+      (16L, 3, "Hello world", 3, 3))
+
+    val stream = failingDataSource(data)
+    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'int2, 'int3, 'proctime.proctime)
+
+    val top3 = new Top3
+    val windowedTable = table
+      .window(Slide over 2.rows every 1.rows on 'proctime as 'w)
+      .groupBy('w, 'int2, 'int3, 'string)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1)
+
+    val sink = new TestingAppendSink
+    windowedTable.toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq("2,2", "2,2", "3,3", "3,3")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // Sliding windows
+  // ----------------------------------------------------------------------------------------------
+
+  @Test
+  def testAllEventTimeSlidingGroupWindowOverTime(): Unit = {
+    // please keep this test in sync with the DataSet variant
+    val stream = failingDataSource(data2)
+      .assignTimestampsAndWatermarks(
+        new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
+    val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+
+    val top3 = new Top3
+    val windowedTable = table
+      .window(Slide over 5.milli every 2.milli on 'long as 'w)
+      .groupBy('w)
+      .flatAggregate(top3('int))
+      .select('f0, 'f1, 'w.start, 'w.end, 'w.rowtime)
+
+    val sink = new TestingAppendSink
+    windowedTable.toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "1,1,1969-12-31T23:59:59.998,1970-01-01T00:00:00.003,1970-01-01T00:00:00.002",
+      "2,2,1969-12-31T23:59:59.998,1970-01-01T00:00:00.003,1970-01-01T00:00:00.002",
+      "2,2,1970-01-01T00:00,1970-01-01T00:00:00.005,1970-01-01T00:00:00.004",
+      "5,5,1970-01-01T00:00,1970-01-01T00:00:00.005,1970-01-01T00:00:00.004",
+      "2,2,1970-01-01T00:00,1970-01-01T00:00:00.005,1970-01-01T00:00:00.004",
+      "2,2,1970-01-01T00:00:00.002,1970-01-01T00:00:00.007,1970-01-01T00:00:00.006",
+      "2,2,1970-01-01T00:00:00.002,1970-01-01T00:00:00.007,1970-01-01T00:00:00.006",
+      "5,5,1970-01-01T00:00:00.002,1970-01-01T00:00:00.007,1970-01-01T00:00:00.006",
+      "3,3,1970-01-01T00:00:00.004,1970-01-01T00:00:00.009,1970-01-01T00:00:00.008",
+      "3,3,1970-01-01T00:00:00.004,1970-01-01T00:00:00.009,1970-01-01T00:00:00.008",
+      "5,5,1970-01-01T00:00:00.004,1970-01-01T00:00:00.009,1970-01-01T00:00:00.008",
+      "3,3,1970-01-01T00:00:00.006,1970-01-01T00:00:00.011,1970-01-01T00:00:00.010",
+      "3,3,1970-01-01T00:00:00.006,1970-01-01T00:00:00.011,1970-01-01T00:00:00.010",
+      "3,3,1970-01-01T00:00:00.008,1970-01-01T00:00:00.013,1970-01-01T00:00:00.012",
+      "4,4,1970-01-01T00:00:00.012,1970-01-01T00:00:00.017,1970-01-01T00:00:00.016",
+      "4,4,1970-01-01T00:00:00.014,1970-01-01T00:00:00.019,1970-01-01T00:00:00.018",
+      "4,4,1970-01-01T00:00:00.016,1970-01-01T00:00:00.021,1970-01-01T00:00:00.020",
+      "4,4,1970-01-01T00:00:00.028,1970-01-01T00:00:00.033,1970-01-01T00:00:00.032",
+      "4,4,1970-01-01T00:00:00.030,1970-01-01T00:00:00.035,1970-01-01T00:00:00.034",
+      "4,4,1970-01-01T00:00:00.032,1970-01-01T00:00:00.037,1970-01-01T00:00:00.036")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testEventTimeSlidingGroupWindowOverTimeOverlappingSplitPane(): Unit = {
+    // please keep this test in sync with the DataSet variant
+    val stream = failingDataSource(data2)
+      .assignTimestampsAndWatermarks(
+        new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
+    val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+
+    val top3 = new Top3
+    val windowedTable = table
+      .window(Slide over 5.milli every 4.milli on 'long as 'w)
+      .groupBy('w, 'string)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1, 'w.start, 'w.end)
+
+    val sink = new TestingAppendSink
+    windowedTable.toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "Hello,2,2,1970-01-01T00:00,1970-01-01T00:00:00.005",
+      "Hello,5,5,1970-01-01T00:00,1970-01-01T00:00:00.005",
+      "Hallo,2,2,1970-01-01T00:00,1970-01-01T00:00:00.005",
+      "Hello world,3,3,1970-01-01T00:00:00.004,1970-01-01T00:00:00.009",
+      "Hello world,3,3,1970-01-01T00:00:00.008,1970-01-01T00:00:00.013",
+      "Hello,3,3,1970-01-01T00:00:00.004,1970-01-01T00:00:00.009",
+      "Hi,1,1,1970-01-01T00:00,1970-01-01T00:00:00.005",
+      "Hello,5,5,1970-01-01T00:00:00.004,1970-01-01T00:00:00.009",
+      "Hello world,4,4,1970-01-01T00:00:00.012,1970-01-01T00:00:00.017",
+      "null,4,4,1970-01-01T00:00:00.028,1970-01-01T00:00:00.033",
+      "Hello world,4,4,1970-01-01T00:00:00.016,1970-01-01T00:00:00.021",
+      "null,4,4,1970-01-01T00:00:00.032,1970-01-01T00:00:00.037")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testEventTimeSlidingGroupWindowOverTimeNonOverlappingSplitPane(): Unit = {
+    // please keep this test in sync with the DataSet variant
+    val stream = failingDataSource(data2)
+      .assignTimestampsAndWatermarks(
+        new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
+    val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+
+    val top3 = new Top3
+    val windowedTable = table
+      .window(Slide over 3.milli every 10.milli on 'long as 'w)
+      .groupBy('w, 'string)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1, 'w.start, 'w.end)
+
+    val sink = new TestingAppendSink
+    windowedTable.toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "null,4,4,1970-01-01T00:00:00.030,1970-01-01T00:00:00.033",
+      "Hallo,2,2,1970-01-01T00:00,1970-01-01T00:00:00.003",
+      "Hi,1,1,1970-01-01T00:00,1970-01-01T00:00:00.003")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testEventTimeGroupWindowWithoutExplicitTimeField(): Unit = {
+    val stream = failingDataSource(data2)
+      .assignTimestampsAndWatermarks(
+        new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
+      .map(t => (t._2, t._6))
+    val table = stream.toTable(tEnv, 'int, 'string, 'rowtime.rowtime)
+
+    val top3 = new Top3
+    val windowedTable = table
+      .window(Slide over 3.milli every 10.milli on 'rowtime as 'w)
+      .groupBy('w, 'string)
+      .flatAggregate(top3('int))
+      .select('string, 'f0, 'f1, 'w.start, 'w.end)
+
+    val sink = new TestingAppendSink
+    windowedTable.toAppendStream[Row].addSink(sink)
+    env.execute()
+    val expected = Seq(
+      "Hallo,2,2,1970-01-01T00:00,1970-01-01T00:00:00.003",
+      "Hi,1,1,1970-01-01T00:00,1970-01-01T00:00:00.003",
+      "null,4,4,1970-01-01T00:00:00.030,1970-01-01T00:00:00.033")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TimeTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TimeTestUtil.scala
@@ -48,7 +48,7 @@ object TimeTestUtil {
     }
 
     override def extractTimestamp(element: T, previousElementTimestamp: Long): Long = {
-      element.productElement(0).asInstanceOf[Long]
+      element.productElement(0).asInstanceOf[Number].longValue()
     }
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/GeneratedNamespaceTableAggsHandleFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/GeneratedNamespaceTableAggsHandleFunction.java
@@ -18,19 +18,15 @@
 
 package org.apache.flink.table.runtime.generated;
 
-import org.apache.flink.table.dataformat.BaseRow;
-
 /**
- * The base class for handling aggregate functions with namespace.
+ * Describes a generated {@link NamespaceTableAggsHandleFunction}.
  */
-public interface NamespaceAggsHandleFunction<N> extends NamespaceAggsHandleFunctionBase<N> {
+public class GeneratedNamespaceTableAggsHandleFunction<N>
+	extends GeneratedClass<NamespaceTableAggsHandleFunction<N>> {
 
-	/**
-	 * Gets the result of the aggregation from the current accumulators and
-	 * namespace properties (like window start).
-	 *
-	 * @param namespace the namespace properties which should be calculated, such window start
-	 * @return the final result (saved in a row) of the current accumulators.
-	 */
-	BaseRow getValue(N namespace) throws Exception;
+	private static final long serialVersionUID = 1L;
+
+	public GeneratedNamespaceTableAggsHandleFunction(String className, String code, Object[] references) {
+		super(className, code, references);
+	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/NamespaceAggsHandleFunctionBase.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/NamespaceAggsHandleFunctionBase.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.generated;
+
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.dataview.StateDataViewStore;
+
+/**
+ * The base class for handling aggregate or table aggregate functions.
+ *
+ * <p>The differences between {@link NamespaceAggsHandleFunctionBase} and
+ * {@link AggsHandleFunctionBase} is that the {@link NamespaceAggsHandleFunctionBase} has namespace.
+ *
+ * @param <N> type of namespace
+ */
+public interface NamespaceAggsHandleFunctionBase<N> extends Function {
+
+	/**
+	 * Initialization method for the function. It is called before the actual working methods.
+	 */
+	void open(StateDataViewStore store) throws Exception;
+
+	/**
+	 * Set the current accumulators (saved in a row) which contains the current
+	 * aggregated results.
+	 * @param accumulators current accumulators
+	 */
+	void setAccumulators(N namespace, BaseRow accumulators) throws Exception;
+
+	/**
+	 * Accumulates the input values to the accumulators.
+	 * @param inputRow input values bundled in a row
+	 */
+	void accumulate(BaseRow inputRow) throws Exception;
+
+	/**
+	 * Retracts the input values from the accumulators.
+	 * @param inputRow input values bundled in a row
+	 */
+	void retract(BaseRow inputRow) throws Exception;
+
+	/**
+	 * Merges the other accumulators into current accumulators.
+	 *
+	 * @param otherAcc The other row of accumulators
+	 */
+	void merge(N namespace, BaseRow otherAcc) throws Exception;
+
+	/**
+	 * Initializes the accumulators and save them to a accumulators row.
+	 *
+	 * @return a row of accumulators which contains the aggregated results
+	 */
+	BaseRow createAccumulators() throws Exception;
+
+	/**
+	 * Gets the current accumulators (saved in a row) which contains the current
+	 * aggregated results.
+	 * @return the current accumulators
+	 */
+	BaseRow getAccumulators() throws Exception;
+
+	/**
+	 * Cleanup for the retired accumulators state.
+	 */
+	void cleanup(N namespace) throws Exception;
+
+	/**
+	 * Tear-down method for this function. It can be used for clean up work.
+	 * By default, this method does nothing.
+	 */
+	void close() throws Exception;
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/NamespaceTableAggsHandleFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/NamespaceTableAggsHandleFunction.java
@@ -19,18 +19,20 @@
 package org.apache.flink.table.runtime.generated;
 
 import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.util.Collector;
 
 /**
- * The base class for handling aggregate functions with namespace.
+ * The base class for handling table aggregate functions with namespace.
  */
-public interface NamespaceAggsHandleFunction<N> extends NamespaceAggsHandleFunctionBase<N> {
+public interface NamespaceTableAggsHandleFunction<N> extends NamespaceAggsHandleFunctionBase<N> {
 
 	/**
-	 * Gets the result of the aggregation from the current accumulators and
-	 * namespace properties (like window start).
+	 * Emits the result of the aggregation from the current accumulators and namespace
+	 * properties (like window start).
 	 *
 	 * @param namespace the namespace properties which should be calculated, such window start
-	 * @return the final result (saved in a row) of the current accumulators.
+	 * @param key       the group key for the current emit.
+	 * @param out       the collector used to emit results.
 	 */
-	BaseRow getValue(N namespace) throws Exception;
+	void emitValue(N namespace, BaseRow key, Collector<BaseRow> out) throws Exception;
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/AggregateWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/AggregateWindowOperator.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.JoinedRow;
+import org.apache.flink.table.dataformat.util.BaseRowUtil;
+import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.operators.window.triggers.Trigger;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link WindowOperator} that dedicates for group aggregate.
+ *
+ * <p>When an element arrives it gets assigned a key using a {@link KeySelector} and it gets
+ * assigned to zero or more windows using a {@link WindowAssigner}. Based on this, the element
+ * is put into panes. A pane is the bucket of elements that have the same key and same
+ * {@code Window}. An element can be in multiple panes if it was assigned to multiple windows by
+ * the
+ * {@code WindowAssigner}.
+ *
+ * <p>Each pane gets its own instance of the provided {@code Trigger}. This trigger determines when
+ * the contents of the pane should be processed to emit results. When a trigger fires,
+ * the given {@link NamespaceAggsHandleFunction#getValue(Object)}
+ * is invoked to produce the results that are emitted for the pane to which the {@code Trigger}
+ * belongs.
+ *
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns.
+ */
+public class AggregateWindowOperator<K, W extends Window> extends WindowOperator<K, W> {
+
+	private static final long serialVersionUID = 1L;
+
+	private NamespaceAggsHandleFunction<W> windowAggAggregator;
+	private GeneratedNamespaceAggsHandleFunction<W> generatedWindowAggregator;
+
+	private transient JoinedRow reuseOutput;
+
+	/**
+	 * The util to compare two BaseRow equals to each other.
+	 * As different BaseRow can't be equals directly, we use a code generated util to handle this.
+	 */
+	protected RecordEqualiser equaliser;
+	private GeneratedRecordEqualiser generatedEqualiser;
+
+	AggregateWindowOperator(
+			NamespaceAggsHandleFunction<W> windowAggregator,
+			RecordEqualiser equaliser,
+			WindowAssigner<W> windowAssigner,
+			Trigger<W> trigger,
+			TypeSerializer<W> windowSerializer,
+			LogicalType[] inputFieldTypes,
+			LogicalType[] accumulatorTypes,
+			LogicalType[] aggResultTypes,
+			LogicalType[] windowPropertyTypes,
+			int rowtimeIndex,
+			boolean sendRetraction,
+			long allowedLateness) {
+		super(windowAggregator,
+			windowAssigner,
+			trigger,
+			windowSerializer,
+			inputFieldTypes,
+			accumulatorTypes,
+			aggResultTypes,
+			windowPropertyTypes,
+			rowtimeIndex,
+			sendRetraction,
+			allowedLateness);
+		this.windowAggAggregator = windowAggregator;
+		this.equaliser = checkNotNull(equaliser);
+	}
+
+	AggregateWindowOperator(
+			GeneratedNamespaceAggsHandleFunction<W> generatedWindowAggregator,
+			GeneratedRecordEqualiser generatedEqualiser,
+			WindowAssigner<W> windowAssigner,
+			Trigger<W> trigger,
+			TypeSerializer<W> windowSerializer,
+			LogicalType[] inputFieldTypes,
+			LogicalType[] accumulatorTypes,
+			LogicalType[] aggResultTypes,
+			LogicalType[] windowPropertyTypes,
+			int rowtimeIndex,
+			boolean sendRetraction,
+			long allowedLateness) {
+		super(windowAssigner,
+			trigger,
+			windowSerializer,
+			inputFieldTypes,
+			accumulatorTypes,
+			aggResultTypes,
+			windowPropertyTypes,
+			rowtimeIndex,
+			sendRetraction,
+			allowedLateness);
+		this.generatedWindowAggregator = generatedWindowAggregator;
+		this.generatedEqualiser = checkNotNull(generatedEqualiser);
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+		reuseOutput = new JoinedRow();
+	}
+
+	@Override
+	protected void compileGeneratedCode() {
+		// compile aggregator
+		if (generatedWindowAggregator != null) {
+			windowAggAggregator = generatedWindowAggregator.newInstance(getRuntimeContext().getUserCodeClassLoader());
+			windowAggregator = windowAggAggregator;
+		}
+
+		// compile equaliser
+		if (generatedEqualiser != null) {
+			equaliser = generatedEqualiser.newInstance(getRuntimeContext().getUserCodeClassLoader());
+		}
+	}
+
+	@Override
+	protected void emitWindowResult(W window) throws Exception {
+		windowFunction.prepareAggregateAccumulatorForEmit(window);
+		BaseRow aggResult = windowAggAggregator.getValue(window);
+		if (sendRetraction) {
+			previousState.setCurrentNamespace(window);
+			BaseRow previousAggResult = previousState.value();
+
+			// has emitted result for the window
+			if (previousAggResult != null) {
+				// current agg is not equal to the previous emitted, should emit retract
+				if (!equaliser.equalsWithoutHeader(aggResult, previousAggResult)) {
+					reuseOutput.replace((BaseRow) getCurrentKey(), previousAggResult);
+					BaseRowUtil.setRetract(reuseOutput);
+					// send retraction
+					collector.collect(reuseOutput);
+					// send accumulate
+					reuseOutput.replace((BaseRow) getCurrentKey(), aggResult);
+					BaseRowUtil.setAccumulate(reuseOutput);
+					collector.collect(reuseOutput);
+					// update previousState
+					previousState.update(aggResult);
+				}
+				// if the previous agg equals to the current agg, no need to send retract and accumulate
+			}
+			// the first fire for the window, only send accumulate
+			else {
+				// send accumulate
+				reuseOutput.replace((BaseRow) getCurrentKey(), aggResult);
+				BaseRowUtil.setAccumulate(reuseOutput);
+				collector.collect(reuseOutput);
+				// update previousState
+				previousState.update(aggResult);
+			}
+		} else {
+			reuseOutput.replace((BaseRow) getCurrentKey(), aggResult);
+			// no need to set header
+			collector.collect(reuseOutput);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/TableAggregateWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/TableAggregateWindowOperator.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.generated.GeneratedNamespaceTableAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceTableAggsHandleFunction;
+import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
+import org.apache.flink.table.runtime.operators.window.triggers.Trigger;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.Collector;
+
+/**
+ * A {@link WindowOperator} that dedicates for group table aggregate.
+ *
+ * <p>When an element arrives it gets assigned a key using a {@link KeySelector} and it gets
+ * assigned to zero or more windows using a {@link WindowAssigner}. Based on this, the element
+ * is put into panes. A pane is the bucket of elements that have the same key and same
+ * {@code Window}. An element can be in multiple panes if it was assigned to multiple windows by
+ * the
+ * {@code WindowAssigner}.
+ *
+ * <p>Each pane gets its own instance of the provided {@code Trigger}. This trigger determines when
+ * the contents of the pane should be processed to emit results. When a trigger fires,
+ * the given {@link NamespaceTableAggsHandleFunction#emitValue(Object, BaseRow, Collector)}
+ * is invoked to produce the results that are emitted for the pane to which the {@code Trigger}
+ * belongs.
+ *
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns.
+ */
+public class TableAggregateWindowOperator<K, W extends Window> extends WindowOperator<K, W> {
+
+	private static final long serialVersionUID = 1L;
+
+	private NamespaceTableAggsHandleFunction<W> windowTableAggAggregator;
+	private GeneratedNamespaceTableAggsHandleFunction<W> generatedWindowTableAggregator;
+
+	TableAggregateWindowOperator(
+		NamespaceTableAggsHandleFunction<W> windowTableAggregator,
+		WindowAssigner<W> windowAssigner,
+		Trigger<W> trigger,
+		TypeSerializer<W> windowSerializer,
+		LogicalType[] inputFieldTypes,
+		LogicalType[] accumulatorTypes,
+		LogicalType[] aggResultTypes,
+		LogicalType[] windowPropertyTypes,
+		int rowtimeIndex,
+		boolean sendRetraction,
+		long allowedLateness) {
+		super(windowTableAggregator,
+			windowAssigner,
+			trigger,
+			windowSerializer,
+			inputFieldTypes,
+			accumulatorTypes,
+			aggResultTypes,
+			windowPropertyTypes,
+			rowtimeIndex,
+			sendRetraction,
+			allowedLateness);
+		this.windowTableAggAggregator = windowTableAggregator;
+	}
+
+	TableAggregateWindowOperator(
+		GeneratedNamespaceTableAggsHandleFunction<W> generatedWindowTableAggregator,
+		WindowAssigner<W> windowAssigner,
+		Trigger<W> trigger,
+		TypeSerializer<W> windowSerializer,
+		LogicalType[] inputFieldTypes,
+		LogicalType[] accumulatorTypes,
+		LogicalType[] aggResultTypes,
+		LogicalType[] windowPropertyTypes,
+		int rowtimeIndex,
+		boolean sendRetraction,
+		long allowedLateness) {
+		super(windowAssigner,
+			trigger,
+			windowSerializer,
+			inputFieldTypes,
+			accumulatorTypes,
+			aggResultTypes,
+			windowPropertyTypes,
+			rowtimeIndex,
+			sendRetraction,
+			allowedLateness);
+		this.generatedWindowTableAggregator = generatedWindowTableAggregator;
+	}
+
+	@Override
+	protected void compileGeneratedCode() {
+		if (generatedWindowTableAggregator != null) {
+			windowTableAggAggregator = generatedWindowTableAggregator.newInstance(getRuntimeContext().getUserCodeClassLoader());
+			windowAggregator = windowTableAggAggregator;
+		}
+	}
+
+	@Override
+	protected void emitWindowResult(W window) throws Exception {
+		windowFunction.prepareAggregateAccumulatorForEmit(window);
+		windowTableAggAggregator.emitValue(window, (BaseRow) getCurrentKey(), collector);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
@@ -41,13 +41,9 @@ import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.dataformat.JoinedRow;
 import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.runtime.dataview.PerWindowStateDataViewStore;
-import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
-import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
-import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
-import org.apache.flink.table.runtime.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
 import org.apache.flink.table.runtime.operators.window.assigners.MergingWindowAssigner;
 import org.apache.flink.table.runtime.operators.window.assigners.PanedWindowAssigner;
 import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
@@ -71,6 +67,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * An operator that implements the logic for windowing based on a {@link WindowAssigner} and
  * {@link Trigger}.
  *
+ *<p>This is the base class for {@link AggregateWindowOperator} and
+ * {@link TableAggregateWindowOperator}. The big difference between {@link AggregateWindowOperator}
+ * and {@link TableAggregateWindowOperator} is {@link AggregateWindowOperator} emits only one
+ * result for each aggregate group, while {@link TableAggregateWindowOperator} can emit multi
+ * results for each aggregate group.
+ *
  * <p>When an element arrives it gets assigned a key using a {@link KeySelector} and it gets
  * assigned to zero or more windows using a {@link WindowAssigner}. Based on this, the element
  * is put into panes. A pane is the bucket of elements that have the same key and same
@@ -80,7 +82,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>Each pane gets its own instance of the provided {@code Trigger}. This trigger determines when
  * the contents of the pane should be processed to emit results. When a trigger fires,
- * the given {@link org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction}
+ * the given {@link org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase}
  * is invoked to produce the results that are emitted for the pane to which the {@code Trigger}
  * belongs.
  *
@@ -94,7 +96,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <K> The type of key returned by the {@code KeySelector}.
  * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns.
  */
-public class WindowOperator<K, W extends Window>
+public abstract class WindowOperator<K, W extends Window>
 		extends AbstractStreamOperator<BaseRow>
 		implements OneInputStreamOperator<BaseRow, BaseRow>, Triggerable<K, W> {
 
@@ -123,7 +125,7 @@ public class WindowOperator<K, W extends Window>
 
 	private final LogicalType[] windowPropertyTypes;
 
-	private final boolean sendRetraction;
+	protected final boolean sendRetraction;
 
 	private final int rowtimeIndex;
 
@@ -139,22 +141,14 @@ public class WindowOperator<K, W extends Window>
 
 	// --------------------------------------------------------------------------------
 
-	private NamespaceAggsHandleFunction<W> windowAggregator;
-	private GeneratedNamespaceAggsHandleFunction<W> generatedWindowAggregator;
-
-	/**
-	 * The util to compare two BaseRow equals to each other.
-	 * As different BaseRow can't be equals directly, we use a code generated util to handle this.
-	 */
-	private RecordEqualiser equaliser;
-	private GeneratedRecordEqualiser generatedEqualiser;
+	protected NamespaceAggsHandleFunctionBase<W> windowAggregator;
 
 	// --------------------------------------------------------------------------------
 
-	private transient InternalWindowProcessFunction<K, W> windowFunction;
+	protected transient InternalWindowProcessFunction<K, W> windowFunction;
 
 	/** This is used for emitting elements with a given timestamp. */
-	private transient TimestampedCollector<BaseRow> collector;
+	protected transient TimestampedCollector<BaseRow> collector;
 
 	/** Flag to prevent duplicate function.close() calls in close() and dispose(). */
 	private transient boolean functionsClosed = false;
@@ -163,11 +157,9 @@ public class WindowOperator<K, W extends Window>
 
 	private transient InternalValueState<K, W, BaseRow> windowState;
 
-	private transient InternalValueState<K, W, BaseRow> previousState;
+	protected transient InternalValueState<K, W, BaseRow> previousState;
 
 	private transient TriggerContext triggerContext;
-
-	private transient JoinedRow reuseOutput;
 
 	// ------------------------------------------------------------------------
 	// Metrics
@@ -178,8 +170,7 @@ public class WindowOperator<K, W extends Window>
 	private transient Gauge<Long> watermarkLatency;
 
 	WindowOperator(
-			NamespaceAggsHandleFunction<W> windowAggregator,
-			RecordEqualiser equaliser,
+			NamespaceAggsHandleFunctionBase<W> windowAggregator,
 			WindowAssigner<W> windowAssigner,
 			Trigger<W> trigger,
 			TypeSerializer<W> windowSerializer,
@@ -192,7 +183,6 @@ public class WindowOperator<K, W extends Window>
 			long allowedLateness) {
 		checkArgument(allowedLateness >= 0);
 		this.windowAggregator = checkNotNull(windowAggregator);
-		this.equaliser = checkNotNull(equaliser);
 		this.windowAssigner = checkNotNull(windowAssigner);
 		this.trigger = checkNotNull(trigger);
 		this.windowSerializer = checkNotNull(windowSerializer);
@@ -211,8 +201,6 @@ public class WindowOperator<K, W extends Window>
 	}
 
 	WindowOperator(
-			GeneratedNamespaceAggsHandleFunction<W> generatedWindowAggregator,
-			GeneratedRecordEqualiser generatedEqualiser,
 			WindowAssigner<W> windowAssigner,
 			Trigger<W> trigger,
 			TypeSerializer<W> windowSerializer,
@@ -224,8 +212,6 @@ public class WindowOperator<K, W extends Window>
 			boolean sendRetraction,
 			long allowedLateness) {
 		checkArgument(allowedLateness >= 0);
-		this.generatedWindowAggregator = checkNotNull(generatedWindowAggregator);
-		this.generatedEqualiser = checkNotNull(generatedEqualiser);
 		this.windowAssigner = checkNotNull(windowAssigner);
 		this.trigger = checkNotNull(trigger);
 		this.windowSerializer = checkNotNull(windowSerializer);
@@ -242,6 +228,8 @@ public class WindowOperator<K, W extends Window>
 
 		setChainingStrategy(ChainingStrategy.ALWAYS);
 	}
+
+	protected abstract void compileGeneratedCode();
 
 	@Override
 	public void open() throws Exception {
@@ -268,15 +256,7 @@ public class WindowOperator<K, W extends Window>
 			this.previousState = (InternalValueState<K, W, BaseRow>) getOrCreateKeyedState(windowSerializer, previousStateDescriptor);
 		}
 
-		// compile aggregator
-		if (generatedWindowAggregator != null) {
-			this.windowAggregator = generatedWindowAggregator.newInstance(getRuntimeContext().getUserCodeClassLoader());
-
-		}
-		// compile equaliser
-		if (generatedEqualiser != null) {
-			this.equaliser = generatedEqualiser.newInstance(getRuntimeContext().getUserCodeClassLoader());
-		}
+		compileGeneratedCode();
 
 		WindowContext windowContext = new WindowContext();
 		windowAggregator.open(new PerWindowStateDataViewStore(
@@ -302,8 +282,6 @@ public class WindowOperator<K, W extends Window>
 					allowedLateness);
 		}
 		windowFunction.open(windowContext);
-
-		reuseOutput = new JoinedRow();
 
 		// metrics
 		this.numLateRecordsDropped = metrics.counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
@@ -421,47 +399,7 @@ public class WindowOperator<K, W extends Window>
 		}
 	}
 
-	/**
-	 * Emits the window result of the given window.
-	 */
-	private void emitWindowResult(W window) throws Exception {
-		BaseRow aggResult = windowFunction.getWindowAggregationResult(window);
-		if (sendRetraction) {
-			previousState.setCurrentNamespace(window);
-			BaseRow previousAggResult = previousState.value();
-
-			// has emitted result for the window
-			if (previousAggResult != null) {
-				// current agg is not equal to the previous emitted, should emit retract
-				if (!equaliser.equalsWithoutHeader(aggResult, previousAggResult)) {
-					reuseOutput.replace((BaseRow) getCurrentKey(), previousAggResult);
-					BaseRowUtil.setRetract(reuseOutput);
-					// send retraction
-					collector.collect(reuseOutput);
-					// send accumulate
-					reuseOutput.replace((BaseRow) getCurrentKey(), aggResult);
-					BaseRowUtil.setAccumulate(reuseOutput);
-					collector.collect(reuseOutput);
-					// update previousState
-					previousState.update(aggResult);
-				}
-				// if the previous agg equals to the current agg, no need to send retract and accumulate
-			}
-			// the first fire for the window, only send accumulate
-			else {
-				// send accumulate
-				reuseOutput.replace((BaseRow) getCurrentKey(), aggResult);
-				BaseRowUtil.setAccumulate(reuseOutput);
-				collector.collect(reuseOutput);
-				// update previousState
-				previousState.update(aggResult);
-			}
-		} else {
-			reuseOutput.replace((BaseRow) getCurrentKey(), aggResult);
-			// no need to set header
-			collector.collect(reuseOutput);
-		}
-	}
+	protected abstract void emitWindowResult(W window) throws Exception;
 
 	/**
 	 * Registers a timer to cleanup the content of the window.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperatorBuilder.java
@@ -21,8 +21,10 @@ package org.apache.flink.table.runtime.operators.window;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.GeneratedNamespaceTableAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceTableAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.operators.window.assigners.CountSlidingWindowAssigner;
 import org.apache.flink.table.runtime.operators.window.assigners.CountTumblingWindowAssigner;
@@ -61,7 +63,9 @@ public class WindowOperatorBuilder {
 	private WindowAssigner<?> windowAssigner;
 	private Trigger<?> trigger;
 	private NamespaceAggsHandleFunction<?> aggregateFunction;
+	private NamespaceTableAggsHandleFunction<?> tableAggregateFunction;
 	private GeneratedNamespaceAggsHandleFunction<?> generatedAggregateFunction;
+	private GeneratedNamespaceTableAggsHandleFunction<?> generatedTableAggregateFunction;
 	private RecordEqualiser equaliser;
 	private GeneratedRecordEqualiser generatedEqualiser;
 	private LogicalType[] accumulatorTypes;
@@ -189,6 +193,31 @@ public class WindowOperatorBuilder {
 		return this;
 	}
 
+	public WindowOperatorBuilder aggregate(
+		NamespaceTableAggsHandleFunction<?> tableAggregateFunction,
+		LogicalType[] accumulatorTypes,
+		LogicalType[] aggResultTypes,
+		LogicalType[] windowPropertyTypes) {
+		ClosureCleaner.clean(tableAggregateFunction, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+		this.accumulatorTypes = accumulatorTypes;
+		this.aggResultTypes = aggResultTypes;
+		this.windowPropertyTypes = windowPropertyTypes;
+		this.tableAggregateFunction = checkNotNull(tableAggregateFunction);
+		return this;
+	}
+
+	public WindowOperatorBuilder aggregate(
+			GeneratedNamespaceTableAggsHandleFunction<?> generatedTableAggregateFunction,
+			LogicalType[] accumulatorTypes,
+			LogicalType[] aggResultTypes,
+			LogicalType[] windowPropertyTypes) {
+		this.accumulatorTypes = accumulatorTypes;
+		this.aggResultTypes = aggResultTypes;
+		this.windowPropertyTypes = windowPropertyTypes;
+		this.generatedTableAggregateFunction = checkNotNull(generatedTableAggregateFunction);
+		return this;
+	}
+
 	public WindowOperatorBuilder withSendRetraction() {
 		this.sendRetraction = true;
 		return this;
@@ -196,9 +225,23 @@ public class WindowOperatorBuilder {
 
 	public WindowOperator build() {
 		checkNotNull(trigger, "trigger is not set");
-		if (generatedAggregateFunction != null && generatedEqualiser != null) {
+		if (generatedTableAggregateFunction != null) {
 			//noinspection unchecked
-			return new WindowOperator(
+			return new TableAggregateWindowOperator(
+					generatedTableAggregateFunction,
+					windowAssigner,
+					trigger,
+					windowAssigner.getWindowSerializer(new ExecutionConfig()),
+					inputFieldTypes,
+					accumulatorTypes,
+					aggResultTypes,
+					windowPropertyTypes,
+					rowtimeIndex,
+					sendRetraction,
+					allowedLateness);
+		} else if (generatedAggregateFunction != null && generatedEqualiser != null) {
+			//noinspection unchecked
+			return new AggregateWindowOperator(
 					generatedAggregateFunction,
 					generatedEqualiser,
 					windowAssigner,
@@ -211,9 +254,23 @@ public class WindowOperatorBuilder {
 					rowtimeIndex,
 					sendRetraction,
 					allowedLateness);
+		} else if (tableAggregateFunction != null) {
+			//noinspection unchecked
+			return new TableAggregateWindowOperator(
+					tableAggregateFunction,
+					windowAssigner,
+					trigger,
+					windowAssigner.getWindowSerializer(new ExecutionConfig()),
+					inputFieldTypes,
+					accumulatorTypes,
+					aggResultTypes,
+					windowPropertyTypes,
+					rowtimeIndex,
+					sendRetraction,
+					allowedLateness);
 		} else {
 			//noinspection unchecked
-			return new WindowOperator(
+			return new AggregateWindowOperator(
 					aggregateFunction,
 					equaliser,
 					windowAssigner,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperatorBuilder.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.runtime.operators.window;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceTableAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
 import org.apache.flink.table.runtime.generated.NamespaceTableAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.operators.window.assigners.CountSlidingWindowAssigner;
@@ -215,6 +217,28 @@ public class WindowOperatorBuilder {
 		this.aggResultTypes = aggResultTypes;
 		this.windowPropertyTypes = windowPropertyTypes;
 		this.generatedTableAggregateFunction = checkNotNull(generatedTableAggregateFunction);
+		return this;
+	}
+
+	@VisibleForTesting
+	public WindowOperatorBuilder aggregate(
+		NamespaceAggsHandleFunctionBase<?> aggregateFunction,
+		RecordEqualiser equaliser,
+		LogicalType[] accumulatorTypes,
+		LogicalType[] aggResultTypes,
+		LogicalType[] windowPropertyTypes) {
+		if (aggregateFunction instanceof NamespaceAggsHandleFunction) {
+			aggregate((NamespaceAggsHandleFunction) aggregateFunction,
+				equaliser,
+				accumulatorTypes,
+				aggResultTypes,
+				windowPropertyTypes);
+		} else {
+			aggregate((NamespaceTableAggsHandleFunction) aggregateFunction,
+				accumulatorTypes,
+				aggResultTypes,
+				windowPropertyTypes);
+		}
 		return this;
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/GeneralWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/GeneralWindowProcessFunction.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.operators.window.internal;
 
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
 import org.apache.flink.table.runtime.operators.window.Window;
 import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
 
@@ -41,7 +41,7 @@ public class GeneralWindowProcessFunction<K, W extends Window>
 
 	public GeneralWindowProcessFunction(
 			WindowAssigner<W> windowAssigner,
-			NamespaceAggsHandleFunction<W> windowAggregator,
+			NamespaceAggsHandleFunctionBase<W> windowAggregator,
 			long allowedLateness) {
 		super(windowAssigner, windowAggregator, allowedLateness);
 	}
@@ -65,13 +65,12 @@ public class GeneralWindowProcessFunction<K, W extends Window>
 	}
 
 	@Override
-	public BaseRow getWindowAggregationResult(W window) throws Exception {
+	public void prepareAggregateAccumulatorForEmit(W window) throws Exception {
 		BaseRow acc = ctx.getWindowAccumulators(window);
 		if (acc == null) {
 			acc = windowAggregator.createAccumulators();
 		}
 		windowAggregator.setAccumulators(window, acc);
-		return windowAggregator.getValue(window);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/InternalWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/InternalWindowProcessFunction.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.operators.window.internal;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
 import org.apache.flink.table.runtime.operators.window.Window;
 import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
 import org.apache.flink.table.runtime.operators.window.triggers.Trigger;
@@ -39,13 +39,13 @@ public abstract class InternalWindowProcessFunction<K, W extends Window> impleme
 	private static final long serialVersionUID = 5191040787066951059L;
 
 	protected final WindowAssigner<W> windowAssigner;
-	protected final NamespaceAggsHandleFunction<W> windowAggregator;
+	protected final NamespaceAggsHandleFunctionBase<W> windowAggregator;
 	protected final long allowedLateness;
 	protected Context<K, W> ctx;
 
 	protected InternalWindowProcessFunction(
 			WindowAssigner<W> windowAssigner,
-			NamespaceAggsHandleFunction<W> windowAggregator,
+			NamespaceAggsHandleFunctionBase<W> windowAggregator,
 			long allowedLateness) {
 		this.windowAssigner = windowAssigner;
 		this.windowAggregator = windowAggregator;
@@ -85,12 +85,12 @@ public abstract class InternalWindowProcessFunction<K, W extends Window> impleme
 			long timestamp) throws Exception;
 
 	/**
-	 * Gets the aggregation result and window properties of the given window.
+	 * Prepares the accumulator of the given window before emit the final result. The accumulator
+	 * is stored in the state or will be created if there is no corresponding accumulator in state.
 	 *
 	 * @param window the window
-	 * @return the aggregation result and window properties
 	 */
-	public abstract BaseRow getWindowAggregationResult(W window) throws Exception;
+	public abstract void prepareAggregateAccumulatorForEmit(W window) throws Exception;
 
 	/**
 	 * Cleans the given window if needed.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/MergingWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/MergingWindowProcessFunction.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
 import org.apache.flink.table.runtime.operators.window.Window;
 import org.apache.flink.table.runtime.operators.window.assigners.MergingWindowAssigner;
 
@@ -48,7 +48,7 @@ public class MergingWindowProcessFunction<K, W extends Window>
 
 	public MergingWindowProcessFunction(
 			MergingWindowAssigner<W> windowAssigner,
-			NamespaceAggsHandleFunction<W> windowAggregator,
+			NamespaceAggsHandleFunctionBase<W> windowAggregator,
 			TypeSerializer<W> windowSerializer,
 			long allowedLateness) {
 		super(windowAssigner, windowAggregator, allowedLateness);
@@ -100,14 +100,13 @@ public class MergingWindowProcessFunction<K, W extends Window>
 	}
 
 	@Override
-	public BaseRow getWindowAggregationResult(W window) throws Exception {
+	public void prepareAggregateAccumulatorForEmit(W window) throws Exception {
 		W stateWindow = mergingWindows.getStateWindow(window);
 		BaseRow acc = ctx.getWindowAccumulators(stateWindow);
 		if (acc == null) {
 			acc = windowAggregator.createAccumulators();
 		}
 		windowAggregator.setAccumulators(stateWindow, acc);
-		return windowAggregator.getValue(window);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/PanedWindowProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/internal/PanedWindowProcessFunction.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.operators.window.internal;
 
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
 import org.apache.flink.table.runtime.operators.window.Window;
 import org.apache.flink.table.runtime.operators.window.assigners.PanedWindowAssigner;
 
@@ -41,7 +41,7 @@ public class PanedWindowProcessFunction<K, W extends Window>
 
 	public PanedWindowProcessFunction(
 			PanedWindowAssigner<W> windowAssigner,
-			NamespaceAggsHandleFunction<W> windowAggregator,
+			NamespaceAggsHandleFunctionBase<W> windowAggregator,
 			long allowedLateness) {
 		super(windowAssigner, windowAggregator, allowedLateness);
 		this.windowAssigner = windowAssigner;
@@ -70,7 +70,7 @@ public class PanedWindowProcessFunction<K, W extends Window>
 	}
 
 	@Override
-	public BaseRow getWindowAggregationResult(W window) throws Exception {
+	public void prepareAggregateAccumulatorForEmit(W window) throws Exception {
 		Iterable<W> panes = windowAssigner.splitIntoPanes(window);
 		BaseRow acc = windowAggregator.createAccumulators();
 		// null namespace means use heap data views
@@ -81,7 +81,6 @@ public class PanedWindowProcessFunction<K, W extends Window>
 				windowAggregator.merge(pane, paneAcc);
 			}
 		}
-		return windowAggregator.getValue(window);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorContractTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorContractTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.GenericRow;
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
+import org.apache.flink.table.runtime.generated.NamespaceTableAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.operators.window.assigners.MergingWindowAssigner;
 import org.apache.flink.table.runtime.operators.window.assigners.WindowAssigner;
@@ -90,7 +92,7 @@ public class WindowOperatorContractTest {
 	}
 
 	@Test
-	public void testAssignerWithMultipleWindows() throws Exception {
+	public void testAssignerWithMultipleWindowsForAggregate() throws Exception {
 		WindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
 		Trigger<TimeWindow> mockTrigger = mockTrigger();
 		NamespaceAggsHandleFunction<TimeWindow> mockAggregate = mockAggsHandleFunction();
@@ -110,6 +112,29 @@ public class WindowOperatorContractTest {
 		verify(mockAggregate, times(2)).getValue(anyTimeWindow());
 		verify(mockAggregate, times(1)).getValue(eq(new TimeWindow(0, 2)));
 		verify(mockAggregate, times(1)).getValue(eq(new TimeWindow(2, 4)));
+	}
+
+	@Test
+	public void testAssignerWithMultipleWindowsForTableAggregate() throws Exception {
+		WindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
+		Trigger<TimeWindow> mockTrigger = mockTrigger();
+		NamespaceTableAggsHandleFunction<TimeWindow> mockAggregate = mockTableAggsHandleFunction();
+
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness =
+			createWindowOperator(mockAssigner, mockTrigger, mockAggregate, 0L);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(any(), anyLong()))
+			.thenReturn(Arrays.asList(new TimeWindow(2, 4), new TimeWindow(0, 2)));
+
+		shouldFireOnElement(mockTrigger);
+
+		testHarness.processElement(record("String", 1, 0L));
+
+		verify(mockAggregate, times(2)).emitValue(anyTimeWindow(), any(), any());
+		verify(mockAggregate, times(1)).emitValue(eq(new TimeWindow(0, 2)), any(), any());
+		verify(mockAggregate, times(1)).emitValue(eq(new TimeWindow(2, 4)), any(), any());
 	}
 
 	@Test
@@ -163,7 +188,7 @@ public class WindowOperatorContractTest {
 	private <W extends Window> KeyedOneInputStreamOperatorTestHarness<BaseRow, BaseRow, BaseRow> createWindowOperator(
 			WindowAssigner<W> assigner,
 			Trigger<W> trigger,
-			NamespaceAggsHandleFunction<W> aggregationsFunction,
+			NamespaceAggsHandleFunctionBase<W> aggregationsFunction,
 			long allowedLateness) throws Exception {
 
 		LogicalType[] inputTypes = new LogicalType[]{new VarCharType(VarCharType.MAX_LENGTH), new IntType()};
@@ -176,26 +201,47 @@ public class WindowOperatorContractTest {
 
 		boolean sendRetraction = allowedLateness > 0;
 
-		WindowOperator operator = new WindowOperator(
-				aggregationsFunction,
-				mock(RecordEqualiser.class),
-				assigner,
-				trigger,
-				assigner.getWindowSerializer(new ExecutionConfig()),
-				inputTypes,
-				outputTypeWithoutKeys,
-				accTypes,
-				windowTypes,
-				2,
-				sendRetraction,
-				allowedLateness);
-
-		return new KeyedOneInputStreamOperatorTestHarness<BaseRow, BaseRow, BaseRow>(
+		if (aggregationsFunction instanceof NamespaceAggsHandleFunction) {
+			AggregateWindowOperator operator = new AggregateWindowOperator(
+					(NamespaceAggsHandleFunction) aggregationsFunction,
+					mock(RecordEqualiser.class),
+					assigner,
+					trigger,
+					assigner.getWindowSerializer(new ExecutionConfig()),
+					inputTypes,
+					outputTypeWithoutKeys,
+					accTypes,
+					windowTypes,
+					2,
+					sendRetraction,
+					allowedLateness);
+			return new KeyedOneInputStreamOperatorTestHarness<BaseRow, BaseRow, BaseRow>(
 				operator, keySelector, keyType);
+		} else {
+			TableAggregateWindowOperator operator = new TableAggregateWindowOperator(
+					(NamespaceTableAggsHandleFunction) aggregationsFunction,
+					assigner,
+					trigger,
+					assigner.getWindowSerializer(new ExecutionConfig()),
+					inputTypes,
+					outputTypeWithoutKeys,
+					accTypes,
+					windowTypes,
+					2,
+					sendRetraction,
+					allowedLateness);
+
+			return new KeyedOneInputStreamOperatorTestHarness<BaseRow, BaseRow, BaseRow>(
+				operator, keySelector, keyType);
+		}
 	}
 
 	private static <W extends Window> NamespaceAggsHandleFunction<W> mockAggsHandleFunction() throws Exception {
 		return mock(NamespaceAggsHandleFunction.class);
+	}
+
+	private static <W extends Window> NamespaceTableAggsHandleFunction<W> mockTableAggsHandleFunction() throws Exception {
+		return mock(NamespaceTableAggsHandleFunction.class);
 	}
 
 	private <W extends Window> Trigger<W> mockTrigger() throws Exception {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorTest.java
@@ -26,9 +26,12 @@ import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.dataformat.JoinedRow;
 import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.runtime.dataview.StateDataViewStore;
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
+import org.apache.flink.table.runtime.generated.NamespaceTableAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.operators.window.assigners.SessionWindowAssigner;
 import org.apache.flink.table.runtime.operators.window.assigners.TumblingWindowAssigner;
@@ -44,10 +47,14 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.util.Collector;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -61,9 +68,43 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Tests for {@link WindowOperator}.
+ * {@link WindowOperator} tests for {@link AggregateWindowOperator} or
+ * {@link TableAggregateWindowOperator}.
+ *
+ * <p>To simplify the testing logic, the table aggregate outputs same value with the aggregate
+ * except that the table aggregate outputs two same records each time.
  */
+@RunWith(Parameterized.class)
 public class WindowOperatorTest {
+
+	@Parameterized.Parameters(name = "isTableAggregate = {0}")
+	public static Collection<Object[]> runMode() {
+		return Arrays.asList(
+			new Object[] { false },
+			new Object[] { true });
+	}
+
+	private final boolean isTableAggregate;
+	private static final SumAndCountAggTimeWindow sumAndCountAggTimeWindow =
+		new SumAndCountAggTimeWindow();
+	private static final SumAndCountTableAggTimeWindow sumAndCountTableAggTimeWindow =
+		new SumAndCountTableAggTimeWindow();
+	private static final SumAndCountAggCountWindow sumAndCountAggCountWindow =
+		new SumAndCountAggCountWindow();
+	private static final SumAndCountTableAggCountWindow sumAndCountTableAggCountWindow =
+		new SumAndCountTableAggCountWindow();
+
+	public WindowOperatorTest(boolean isTableAggregate) {
+		this.isTableAggregate = isTableAggregate;
+	}
+
+	private NamespaceAggsHandleFunctionBase getTimeWindowAggFunction() {
+		return isTableAggregate ? sumAndCountTableAggTimeWindow : sumAndCountAggTimeWindow;
+	}
+
+	private NamespaceAggsHandleFunctionBase getCountWindowAggFunction() {
+		return isTableAggregate ? sumAndCountTableAggCountWindow : sumAndCountAggCountWindow;
+	}
 
 	// For counting if close() is called the correct number of times on the SumReducer
 	private static AtomicInteger closeCalled = new AtomicInteger(0);
@@ -91,6 +132,15 @@ public class WindowOperatorTest {
 			outputType.getFieldTypes(),
 			new GenericRowRecordSortComparator(0, new VarCharType(VarCharType.MAX_LENGTH)));
 
+	private ConcurrentLinkedQueue<Object> doubleRecord(boolean isDouble, StreamRecord<BaseRow> record) {
+		ConcurrentLinkedQueue<Object> results = new ConcurrentLinkedQueue<>();
+		results.add(record);
+		if (isDouble) {
+			results.add(record);
+		}
+		return results;
+	}
+
 	@Test
 	public void testEventTimeSlidingWindows() throws Exception {
 		closeCalled.set(0);
@@ -100,7 +150,7 @@ public class WindowOperatorTest {
 				.withInputFields(inputFieldTypes)
 				.sliding(Duration.ofSeconds(3), Duration.ofSeconds(1))
 				.withEventTime(2)
-				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.aggregate(getTimeWindowAggFunction(), equaliser, accTypes, aggResultTypes, windowTypes)
 				.build();
 
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
@@ -123,19 +173,19 @@ public class WindowOperatorTest {
 		testHarness.processElement(record("key2", 1, 1000L));
 
 		testHarness.processWatermark(new Watermark(999));
-		expectedOutput.add(record("key1", 3L, 3L, -2000L, 1000L, 999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 3L, 3L, -2000L, 1000L, 999L)));
 		expectedOutput.add(new Watermark(999));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processWatermark(new Watermark(1999));
-		expectedOutput.add(record("key1", 3L, 3L, -1000L, 2000L, 1999L));
-		expectedOutput.add(record("key2", 3L, 3L, -1000L, 2000L, 1999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 3L, 3L, -1000L, 2000L, 1999L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 3L, 3L, -1000L, 2000L, 1999L)));
 		expectedOutput.add(new Watermark(1999));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processWatermark(new Watermark(2999));
-		expectedOutput.add(record("key1", 3L, 3L, 0L, 3000L, 2999L));
-		expectedOutput.add(record("key2", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 3L, 3L, 0L, 3000L, 2999L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 3L, 3L, 0L, 3000L, 2999L)));
 		expectedOutput.add(new Watermark(2999));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -150,17 +200,17 @@ public class WindowOperatorTest {
 		testHarness.open();
 
 		testHarness.processWatermark(new Watermark(3999));
-		expectedOutput.add(record("key2", 5L, 5L, 1000L, 4000L, 3999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 5L, 5L, 1000L, 4000L, 3999L)));
 		expectedOutput.add(new Watermark(3999));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processWatermark(new Watermark(4999));
-		expectedOutput.add(record("key2", 2L, 2L, 2000L, 5000L, 4999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 2L, 2L, 2000L, 5000L, 4999L)));
 		expectedOutput.add(new Watermark(4999));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processWatermark(new Watermark(5999));
-		expectedOutput.add(record("key2", 2L, 2L, 3000L, 6000L, 5999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 2L, 2L, 3000L, 6000L, 5999L)));
 		expectedOutput.add(new Watermark(5999));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -187,7 +237,7 @@ public class WindowOperatorTest {
 				.withInputFields(inputFieldTypes)
 				.sliding(Duration.ofSeconds(3), Duration.ofSeconds(1))
 				.withProcessingTime()
-				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.aggregate(getTimeWindowAggFunction(), equaliser, accTypes, aggResultTypes, windowTypes)
 				.build();
 
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
@@ -202,7 +252,7 @@ public class WindowOperatorTest {
 
 		testHarness.setProcessingTime(1000);
 
-		expectedOutput.add(record("key2", 1L, 1L, -2000L, 1000L, 999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 1L, 1L, -2000L, 1000L, 999L)));
 
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -211,7 +261,7 @@ public class WindowOperatorTest {
 
 		testHarness.setProcessingTime(2000);
 
-		expectedOutput.add(record("key2", 3L, 3L, -1000L, 2000L, 1999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 3L, 3L, -1000L, 2000L, 1999L)));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processElement(record("key1", 1, Long.MAX_VALUE));
@@ -219,8 +269,8 @@ public class WindowOperatorTest {
 
 		testHarness.setProcessingTime(3000);
 
-		expectedOutput.add(record("key2", 3L, 3L, 0L, 3000L, 2999L));
-		expectedOutput.add(record("key1", 2L, 2L, 0L, 3000L, 2999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 3L, 3L, 0L, 3000L, 2999L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 2L, 2L, 0L, 3000L, 2999L)));
 
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -230,10 +280,10 @@ public class WindowOperatorTest {
 
 		testHarness.setProcessingTime(7000);
 
-		expectedOutput.add(record("key2", 2L, 2L, 1000L, 4000L, 3999L));
-		expectedOutput.add(record("key1", 5L, 5L, 1000L, 4000L, 3999L));
-		expectedOutput.add(record("key1", 5L, 5L, 2000L, 5000L, 4999L));
-		expectedOutput.add(record("key1", 3L, 3L, 3000L, 6000L, 5999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 2L, 2L, 1000L, 4000L, 3999L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 5L, 5L, 1000L, 4000L, 3999L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 5L, 5L, 2000L, 5000L, 4999L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 3L, 3L, 3000L, 6000L, 5999L)));
 
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -250,7 +300,7 @@ public class WindowOperatorTest {
 				.withInputFields(inputFieldTypes)
 				.tumble(Duration.ofSeconds(3))
 				.withEventTime(2)
-				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.aggregate(getTimeWindowAggFunction(), equaliser, accTypes, aggResultTypes, windowTypes)
 				.build();
 
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
@@ -290,8 +340,8 @@ public class WindowOperatorTest {
 		testHarness.open();
 
 		testHarness.processWatermark(new Watermark(2999));
-		expectedOutput.add(record("key1", 3L, 3L, 0L, 3000L, 2999L));
-		expectedOutput.add(record("key2", 3L, 3L, 0L, 3000L, 2999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 3L, 3L, 0L, 3000L, 2999L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 3L, 3L, 0L, 3000L, 2999L)));
 		expectedOutput.add(new Watermark(2999));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -304,7 +354,7 @@ public class WindowOperatorTest {
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processWatermark(new Watermark(5999));
-		expectedOutput.add(record("key2", 2L, 2L, 3000L, 6000L, 5999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 2L, 2L, 3000L, 6000L, 5999L)));
 		expectedOutput.add(new Watermark(5999));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -576,7 +626,7 @@ public class WindowOperatorTest {
 				.withInputFields(inputFieldTypes)
 				.tumble(Duration.ofSeconds(3))
 				.withProcessingTime()
-				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.aggregate(getTimeWindowAggFunction(), equaliser, accTypes, aggResultTypes, windowTypes)
 				.build();
 
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
@@ -597,8 +647,8 @@ public class WindowOperatorTest {
 
 		testHarness.setProcessingTime(5000);
 
-		expectedOutput.add(record("key2", 3L, 3L, 0L, 3000L, 2999L));
-		expectedOutput.add(record("key1", 2L, 2L, 0L, 3000L, 2999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 3L, 3L, 0L, 3000L, 2999L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 2L, 2L, 0L, 3000L, 2999L)));
 
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -608,7 +658,7 @@ public class WindowOperatorTest {
 
 		testHarness.setProcessingTime(7000);
 
-		expectedOutput.add(record("key1", 3L, 3L, 3000L, 6000L, 5999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 3L, 3L, 3000L, 6000L, 5999L)));
 
 		assertEquals(0L, operator.getWatermarkLatency().getValue());
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
@@ -626,7 +676,7 @@ public class WindowOperatorTest {
 				.withInputFields(inputFieldTypes)
 				.session(Duration.ofSeconds(3))
 				.withEventTime(2)
-				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.aggregate(getTimeWindowAggFunction(), equaliser, accTypes, aggResultTypes, windowTypes)
 				.build();
 
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
@@ -664,10 +714,10 @@ public class WindowOperatorTest {
 
 		testHarness.processWatermark(new Watermark(12000));
 
-		expectedOutput.add(record("key1", 6L, 3L, 10L, 5500L, 5499L));
-		expectedOutput.add(record("key2", 6L, 3L, 0L, 5500L, 5499L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 6L, 3L, 10L, 5500L, 5499L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 6L, 3L, 0L, 5500L, 5499L)));
 
-		expectedOutput.add(record("key2", 20L, 4L, 5501L, 9050L, 9049L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 20L, 4L, 5501L, 9050L, 9049L)));
 		expectedOutput.add(new Watermark(12000));
 
 		// add a late data
@@ -677,7 +727,7 @@ public class WindowOperatorTest {
 
 		testHarness.processWatermark(new Watermark(17999));
 
-		expectedOutput.add(record("key2", 30L, 2L, 15000L, 18000L, 17999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 30L, 2L, 15000L, 18000L, 17999L)));
 		expectedOutput.add(new Watermark(17999));
 
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
@@ -701,7 +751,7 @@ public class WindowOperatorTest {
 				.withInputFields(inputFieldTypes)
 				.session(Duration.ofSeconds(3))
 				.withProcessingTime()
-				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.aggregate(getTimeWindowAggFunction(), equaliser, accTypes, aggResultTypes, windowTypes)
 				.build();
 
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
@@ -722,7 +772,7 @@ public class WindowOperatorTest {
 
 		testHarness.setProcessingTime(5000);
 
-		expectedOutput.add(record("key2", 2L, 2L, 3L, 4000L, 3999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 2L, 2L, 3L, 4000L, 3999L)));
 
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -734,8 +784,8 @@ public class WindowOperatorTest {
 
 		testHarness.setProcessingTime(10000);
 
-		expectedOutput.add(record("key2", 2L, 2L, 5000L, 8000L, 7999L));
-		expectedOutput.add(record("key1", 3L, 3L, 5000L, 8000L, 7999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 2L, 2L, 5000L, 8000L, 7999L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 3L, 3L, 5000L, 8000L, 7999L)));
 
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -759,7 +809,7 @@ public class WindowOperatorTest {
 				.withInputFields(inputFieldTypes)
 				.assigner(new PointSessionWindowAssigner(3000))
 				.withEventTime(2)
-				.aggregate(new SumAndCountAggTimeWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.aggregate(getTimeWindowAggFunction(), equaliser, accTypes, aggResultTypes, windowTypes)
 				.build();
 
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
@@ -789,8 +839,8 @@ public class WindowOperatorTest {
 
 		testHarness.processWatermark(new Watermark(12000));
 
-		expectedOutput.add(record("key1", 36L, 3L, 10L, 4000L, 3999L));
-		expectedOutput.add(record("key2", 67L, 3L, 0L, 3000L, 2999L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 36L, 3L, 10L, 4000L, 3999L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 67L, 3L, 0L, 3000L, 2999L)));
 		expectedOutput.add(new Watermark(12000));
 
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
@@ -956,7 +1006,7 @@ public class WindowOperatorTest {
 		WindowOperator operator = WindowOperatorBuilder.builder()
 				.withInputFields(inputFieldTypes)
 				.countWindow(windowSize)
-				.aggregate(new SumAndCountAggCountWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.aggregate(getCountWindowAggFunction(), equaliser, accTypes, aggResultTypes, windowTypes)
 				.build();
 
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
@@ -973,7 +1023,7 @@ public class WindowOperatorTest {
 
 		testHarness.processWatermark(new Watermark(12000));
 		testHarness.setProcessingTime(12000L);
-		expectedOutput.add(record("key2", 6L, 3L, 0L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 6L, 3L, 0L)));
 		expectedOutput.add(new Watermark(12000));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -988,7 +1038,7 @@ public class WindowOperatorTest {
 		testHarness.open();
 
 		testHarness.processElement(record("key1", 2, 2500L));
-		expectedOutput.add(record("key1", 5L, 3L, 0L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 5L, 3L, 0L)));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processElement(record("key2", 4, 5501L));
@@ -996,18 +1046,18 @@ public class WindowOperatorTest {
 		testHarness.processElement(record("key2", 5, 6000L));
 		testHarness.processElement(record("key2", 6, 6050L));
 
-		expectedOutput.add(record("key2", 14L, 3L, 1L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 14L, 3L, 1L)));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processElement(record("key1", 3, 4000L));
 		testHarness.processElement(record("key2", 10, 15000L));
 		testHarness.processElement(record("key2", 20, 15000L));
-		expectedOutput.add(record("key2", 36L, 3L, 2L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 36L, 3L, 2L)));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processElement(record("key1", 2, 2500L));
 		testHarness.processElement(record("key1", 2, 2500L));
-		expectedOutput.add(record("key1", 7L, 3L, 1L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 7L, 3L, 1L)));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.close();
@@ -1026,7 +1076,7 @@ public class WindowOperatorTest {
 		WindowOperator operator = WindowOperatorBuilder.builder()
 				.withInputFields(inputFieldTypes)
 				.countWindow(windowSize, windowSlide)
-				.aggregate(new SumAndCountAggCountWindow(), equaliser, accTypes, aggResultTypes, windowTypes)
+				.aggregate(getCountWindowAggFunction(), equaliser, accTypes, aggResultTypes, windowTypes)
 				.build();
 
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
@@ -1045,7 +1095,7 @@ public class WindowOperatorTest {
 
 		testHarness.processWatermark(new Watermark(12000));
 		testHarness.setProcessingTime(12000L);
-		expectedOutput.add(record("key2", 15L, 5L, 0L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 15L, 5L, 0L)));
 		expectedOutput.add(new Watermark(12000));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -1062,14 +1112,14 @@ public class WindowOperatorTest {
 		testHarness.processElement(record("key1", 3, 2500L));
 		testHarness.processElement(record("key1", 4, 2500L));
 		testHarness.processElement(record("key1", 5, 2500L));
-		expectedOutput.add(record("key1", 15L, 5L, 0L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 15L, 5L, 0L)));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processElement(record("key2", 6, 6000L));
 		testHarness.processElement(record("key2", 7, 6000L));
 		testHarness.processElement(record("key2", 8, 6050L));
 		testHarness.processElement(record("key2", 9, 6050L));
-		expectedOutput.add(record("key2", 30L, 5L, 1L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 30L, 5L, 1L)));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.processElement(record("key1", 6, 4000L));
@@ -1077,8 +1127,8 @@ public class WindowOperatorTest {
 		testHarness.processElement(record("key1", 8, 4000L));
 		testHarness.processElement(record("key2", 10, 15000L));
 		testHarness.processElement(record("key2", 11, 15000L));
-		expectedOutput.add(record("key1", 30L, 5L, 1L));
-		expectedOutput.add(record("key2", 45L, 5L, 2L));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key1", 30L, 5L, 1L)));
+		expectedOutput.addAll(doubleRecord(isTableAggregate, record("key2", 45L, 5L, 2L)));
 		assertor.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput());
 
 		testHarness.close();
@@ -1126,7 +1176,9 @@ public class WindowOperatorTest {
 	}
 
 	// sum, count, window_start, window_end
-	private static class SumAndCountAggTimeWindow extends SumAndCountAgg<TimeWindow> {
+	private static class SumAndCountAggTimeWindow
+		extends SumAndCountAggBase<TimeWindow>
+		implements NamespaceAggsHandleFunction<TimeWindow> {
 
 		private static final long serialVersionUID = 2062031590687738047L;
 
@@ -1150,7 +1202,9 @@ public class WindowOperatorTest {
 	}
 
 	// sum, count, window_id
-	private static class SumAndCountAggCountWindow extends SumAndCountAgg<CountWindow> {
+	private static class SumAndCountAggCountWindow
+		extends SumAndCountAggBase<CountWindow>
+		implements NamespaceAggsHandleFunction<CountWindow> {
 
 		private static final long serialVersionUID = -2634639678371135643L;
 
@@ -1171,23 +1225,80 @@ public class WindowOperatorTest {
 		}
 	}
 
-	private static class SumAndCountAgg<W extends Window> implements NamespaceAggsHandleFunction<W> {
+	// (table aggregate) sum, count, window_start, window_end
+	private static class SumAndCountTableAggTimeWindow
+		extends SumAndCountAggBase<TimeWindow>
+		implements NamespaceTableAggsHandleFunction<TimeWindow>  {
 
-		private static final long serialVersionUID = 2822222597580664436L;
+		private static final long serialVersionUID = 2062031590687738047L;
 
-		protected boolean openCalled = false;
+		@Override
+		public void emitValue(TimeWindow namespace, BaseRow key, Collector<BaseRow> out) throws Exception {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			GenericRow row = new GenericRow(5);
+			if (!sumIsNull) {
+				row.setField(0, sum);
+			}
+			if (!countIsNull) {
+				row.setField(1, count);
+			}
+			row.setField(2, namespace.getStart());
+			row.setField(3, namespace.getEnd());
+			row.setField(4, namespace.maxTimestamp());
+
+			result.replace(key, row);
+			// Simply output two lines
+			out.collect(result);
+			out.collect(result);
+		}
+	}
+
+	// (table aggregate) sum, count, window_id
+	private static class SumAndCountTableAggCountWindow
+		extends SumAndCountAggBase<CountWindow>
+		implements NamespaceTableAggsHandleFunction<CountWindow> {
+
+		private static final long serialVersionUID = -2634639678371135643L;
+
+		@Override
+		public void emitValue(CountWindow namespace, BaseRow key, Collector<BaseRow> out) throws Exception {
+			if (!openCalled) {
+				fail("Open was not called");
+			}
+			GenericRow row = new GenericRow(3);
+			if (!sumIsNull) {
+				row.setField(0, sum);
+			}
+			if (!countIsNull) {
+				row.setField(1, count);
+			}
+			row.setField(2, namespace.getId());
+
+			result.replace(key, row);
+			// Simply output two lines
+			out.collect(result);
+			out.collect(result);
+		}
+	}
+
+	private static class SumAndCountAggBase<W extends Window> {
+
+		boolean openCalled;
 
 		long sum;
 		boolean sumIsNull;
 		long count;
 		boolean countIsNull;
 
-		@Override
+		protected transient JoinedRow result;
+
 		public void open(StateDataViewStore store) throws Exception {
 			openCalled = true;
+			result = new JoinedRow();
 		}
 
-		@Override
 		public void setAccumulators(W namespace, BaseRow acc) throws Exception {
 			if (!openCalled) {
 				fail("Open was not called");
@@ -1203,7 +1314,6 @@ public class WindowOperatorTest {
 			}
 		}
 
-		@Override
 		public void accumulate(BaseRow inputRow) throws Exception {
 			if (!openCalled) {
 				fail("Open was not called");
@@ -1215,7 +1325,6 @@ public class WindowOperatorTest {
 			}
 		}
 
-		@Override
 		public void retract(BaseRow inputRow) throws Exception {
 			if (!openCalled) {
 				fail("Open was not called");
@@ -1227,7 +1336,6 @@ public class WindowOperatorTest {
 			}
 		}
 
-		@Override
 		public void merge(W w, BaseRow otherAcc) throws Exception {
 			if (!openCalled) {
 				fail("Open was not called");
@@ -1242,7 +1350,6 @@ public class WindowOperatorTest {
 			}
 		}
 
-		@Override
 		public BaseRow createAccumulators() {
 			if (!openCalled) {
 				fail("Open was not called");
@@ -1253,7 +1360,6 @@ public class WindowOperatorTest {
 			return acc;
 		}
 
-		@Override
 		public BaseRow getAccumulators() throws Exception {
 			if (!openCalled) {
 				fail("Open was not called");
@@ -1268,27 +1374,10 @@ public class WindowOperatorTest {
 			return row;
 		}
 
-		@Override
-		public BaseRow getValue(W namespace) throws Exception {
-			if (!openCalled) {
-				fail("Open was not called");
-			}
-			GenericRow row = new GenericRow(2);
-			if (!sumIsNull) {
-				row.setField(0, sum);
-			}
-			if (!countIsNull) {
-				row.setField(1, count);
-			}
-			return row;
-		}
-
-		@Override
 		public void cleanup(W window) {
 
 		}
 
-		@Override
 		public void close() {
 			closeCalled.incrementAndGet();
 		}


### PR DESCRIPTION
## What is the purpose of the change

This pull request ports window flatAggregate from Flink planner to Blink planner. 

The changes mainly include two modules: blink-planner and blink-runtime. The code of the API part can be reused as the two planner share the same API.

## Brief change log
This pr is further split into the following 4 commits:

1. Add plan support for table aggregate. 
  This commit adds RelNodes(Logical, FlinkLogical and StreamExec) and Rules in blink planner. The execution procedures are: 
  First, the WindowAggregate QueryOperation node in API level will be converted to a LogicalWindowTableAggregate relnode in `QueryOperationConverter`.
  Second, the LogicalWindowTableAggregate will be converted to a FlinkLogicalWindowTableAggregate by the rule in logical optimization phase.
  Third, the FlinkLogicalWindowTableAggregate will be converted to a StreamExecGroupWindowTableAggregate by the rule in physical optimization phase.

2. Add runtime support for table aggregate.
  This commit adds codegen and window operator support for window table aggregete. 
  The AggCodeGen generates a NamespaceTableAggsHandleFunction which is used in the window operator.
  For window operator, this commit refactors the previous window operator by adding a base window operator(`WindowOperator`) and two sub window operators(`AggregateWindowOperator` and `TableAggregateWindowOperator`).
  Additionally, to make the refactor possible, this commit also change the window processing function(`InternalWindowProcessFunction`) by changing the `getWindowAggregationResult` method to `prepareAggregateAccumulatorForEmit`.
  The `prepareAggregateAccumulatorForEmit` method returns the accumulator, with which the `AggregateWindowOperator` can use getValue to return result and the `TableAggregateWindowOperator` can use emitValue to return results.

3. Add window operator tests for window table aggregate.
  Change the `WindowOperatorTest` into a parameterized test which can test both aggregate and table aggregate.
  To simplify the testing logic, the table aggregate outputs same value with the aggregate except that the table aggregate outputs two same records each time.
  
4. Support WindowTableAggregate in some MetadataHandler.
  MetadataHandler is used to provide Metadata of a relational expression. For example, provide the unique key information of a relnode. The information can be used during optimization.
  This commit adds WindowTableAggregate support in `FlinkRelMdColumnInterval`, `FlinkRelMdFilteredColumnInterval` and `FlinkRelMdModifiedMonotonicity`. The absence of WindowTableAggregate in other MetadataHandlers mainly because:
   
- The WindowTableAggregate can not provide uniqueness information which is required in FlinkRelMdColumnUniqueness, FlinkRelMdDistinctRowCount, FlinkRelMdUniqueGroups, FlinkRelMdUniqueKeys. 
- Most of the MetadataHandlers are not been used in streaming jobs，such as FlinkRelMdPercentageOriginalRows，FlinkRelMdPopulationSize, FlinkRelMdRowCount, etc.


## Verifying this change
This change added tests and can be verified as follows:
 TODO

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
 